### PR TITLE
monkey patch for actionview security issue

### DIFF
--- a/config/initializers/formats_filter.rb
+++ b/config/initializers/formats_filter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ActionDispatch::Request.prepend(Module.new do
+  def formats
+    super().select do |format|
+      format.symbol || format.ref == "*/*"
+    end
+  end
+end)


### PR DESCRIPTION
Recommendation is to move the gem to version 5.1.6.2, but that would require an update of Rails from 5.0 to 5.1.  That would require more extensive testing.

There is an alternative recommendation that includes a monkey patch to set format filters that allows us to stay on Rails 5.0.

Rails will be updated when production is moved to AWS.