### PR TITLE
tmp pin of sprockets

### DIFF
--- a/.ebextensions/update_bundler.config
+++ b/.ebextensions/update_bundler.config
@@ -1,3 +1,3 @@
-container_commands:
+commands:
   update_bundler:
     command: /opt/rubies/ruby-2.5.5/bin/gem install bundler -v 2.1.4

--- a/Gemfile
+++ b/Gemfile
@@ -77,8 +77,9 @@ group :test do
   # gem 'rspec-activemodel-mocks'
 end
 
-# tmp pin of autoprefixer to avoid nodes version error
-gem 'autoprefixer-rails', '8.5.2'
+# tmp pins for incompatibilities
+gem 'autoprefixer-rails', '8.5.2' # avoid nodes version error
+gem 'sprockets', '3.7.2' # avoid err working with font-awesome 4.5 - corrected in 5.12
 
 # ruby "2.5.3"
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -428,7 +428,7 @@ GEM
       ruby-progressbar
       rubyzip
     spring (2.1.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -524,6 +524,7 @@ DEPENDENCIES
   sitemap_generator
   solr_wrapper (>= 0.3)
   spring
+  sprockets (= 3.7.2)
   sqlite3
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
sprockets 4 is incompatible with font-awesome 4.5.  It is compatible with font-awesome 5.12.  This pins sprockets to the previous version used by exhibits, i.e. 3.7.2.  This also reverts changes to update_bundler.config as it was likely correct the way it was before.

Ref:

https://github.com/FortAwesome/font-awesome-sass/commit/b8dd32cf3bcd5d14c12543d767f8db68b31a6a9b

https://github.com/rails/sprockets-rails/issues/269

https://github.com/rails/sprockets-rails/issues/333