### PR TITLE
use relative path for logs as the script runs in the staging directory

### DIFF
--- a/.ebextensions/sidekiq_permissions.config
+++ b/.ebextensions/sidekiq_permissions.config
@@ -1,42 +1,41 @@
 commands:
-  create_log_dir:
-    command: "mkdir -p /var/app/current/log"
+  create_post_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/appdeploy/post"
     ignoreErrors: true
 files:
   "/opt/elasticbeanstalk/hooks/appdeploy/post/40_chmod_logs.sh":
-       mode: "000755"
-       owner: root
-       group: root
-       content: |
-         #!/usr/bin/env bash
-         . /opt/elasticbeanstalk/support/envvars
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      . /opt/elasticbeanstalk/support/envvars
 
-         SIDEKIQ_LOG=$EB_APP_DEPLOY_DIR/log/sidekiq.log
+      SIDEKIQ_LOG=log/sidekiq.log
 
-         case $RACK_ENV in
-           "integration")
-             RAILS_LOG=$EB_APP_DEPLOY_DIR/log/integration.log
-             ;;
-           "staging")
-             RAILS_LOG=$EB_APP_DEPLOY_DIR/log/staging.log
-             ;;
-           "production")
-             RAILS_LOG=$EB_APP_DEPLOY_DIR/log/production.log
-             ;;
-         esac
+      case $RACK_ENV in
+        "integration")
+          RAILS_LOG=log/integration.log
+          ;;
+        "staging")
+          RAILS_LOG=log/staging.log
+          ;;
+        "production")
+          RAILS_LOG=log/production.log
+          ;;
+      esac
 
-echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
-echo ' '
-echo 'SIDEKIQ_LOG='+$SIDEKIQ_LOG
-echo 'RAILS_LOG='+$RAILS_LOG
-echo ' '
-echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+      echo '===================== Log Locations ====================='
+      echo ' '
+      echo 'SIDEKIQ_LOG='$SIDEKIQ_LOG
+      echo 'RAILS_LOG='$RAILS_LOG
+      echo ' '
+      echo '========================================================='
 
-         sudo touch $SIDEKIQ_LOG
-         sudo chmod 0664 $SIDEKIQ_LOG
-         sudo touch $RAILS_LOG
-         sudo chmod 0664 $RAILS_LOG
-
+      touch $SIDEKIQ_LOG
+      chmod 0664 $SIDEKIQ_LOG
+      touch $RAILS_LOG
+      chmod 0664 $RAILS_LOG
 
 container_commands:
   run_chmod_logs:


### PR DESCRIPTION
Makes fixes that I think are needed including...
* remove command to create /var/app/current/log directory
* make comment lines indent the same as preceding lines to have valid iml
* don't need sudo as the script runs as root user
* use relative path since script executes in staging directory