### PR TITLE
set acl to public-read to allow attachments to be viewable without expiring

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,6 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted"><small>Cornell Exhibits v1.0.0</small></p>
+		<p class="text-muted"><small>Cornell Exhibits v1.0.1.rc1</small></p>
 	</div>
 </footer>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,8 +1,8 @@
 if ENV['S3_KEY_ID'].present?
   CarrierWave.configure do |config|
-    config.storage = :aws
+    config.storage    = :aws
     config.aws_bucket = ENV['S3_BUCKET']
-    config.aws_acl = 'bucket-owner-full-control'
+    config.aws_acl    = 'public-read'
 
     config.aws_credentials = {
       access_key_id:      ENV['S3_KEY_ID'],


### PR DESCRIPTION
This addresses the expiration of images uploaded via Uploaded Item Row.