### PR TITLE
patch s3 access to remove expiry token from attachment URLs

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,6 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted"><small>Cornell Exhibits v1.0.0</small></p>
+		<p class="text-muted"><small>Cornell Exhibits v1.0.1.rc2</small></p>
 	</div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,6 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted"><small>Cornell Exhibits v1.0.1.rc1</small></p>
+		<p class="text-muted"><small>Cornell Exhibits v1.0.0</small></p>
 	</div>
 </footer>

--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,0 +1,28 @@
+<div class="content-block item-text row">
+  <div class="items-col spotlight-flexbox <%= 'col-md-6' if uploaded_items_block.text? %> col-xs-12 uploaded-items-block pull-<%= uploaded_items_block.content_align %>">
+    <% if uploaded_items_block.files.present? %>
+      <% uploaded_items_block.files.each do |file| %>
+        <div class="box" data-id="<%= file[:id] %>">
+          <div class="contents">
+            <div class="thumbnail">
+              <% url = file[:url].split('?').first %>
+              <img src='<%= url %>' alt='<%= file[:title] %>' />
+              <% if file[:caption].present? %>
+                <div class="caption">
+                  <%= file[:caption] %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if uploaded_items_block.text? %>
+    <div class="text-col col-md-6">
+      <%= content_tag(:h3, uploaded_items_block.title) if uploaded_items_block.title.present? %>
+      <%= sir_trevor_markdown uploaded_items_block.text %>
+    </div>
+  <% end %>
+</div>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,8 +1,8 @@
 if ENV['S3_KEY_ID'].present?
   CarrierWave.configure do |config|
-    config.storage    = :aws
+    config.storage = :aws
     config.aws_bucket = ENV['S3_BUCKET']
-    config.aws_acl    = 'public-read'
+    config.aws_acl = 'bucket-owner-full-control'
 
     config.aws_credentials = {
       access_key_id:      ENV['S3_KEY_ID'],


### PR DESCRIPTION
This patch simply removes everything after the ? in the attachment URL.  It relies on the s3 ACLs to prevent access if access should not be allowed.