### PR TITLE
give exhibit admin permission to upload a file as the masthead

### DIFF
--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -26,7 +26,7 @@ module Spotlight
         can :manage, [Spotlight::BlacklightConfiguration, Spotlight::ContactEmail], exhibit_id: user.admin_roles.pluck(:resource_id)
         can :manage, Spotlight::Role, resource_id: user.admin_roles.pluck(:resource_id), resource_type: 'Spotlight::Exhibit'
 
-        can :manage, PaperTrail::Version if user.roles.any?
+        can :manage, [PaperTrail::Version, Spotlight::FeaturedImage] if user.roles.any?
 
         # exhibit curator
         can :manage, [


### PR DESCRIPTION
fixes #282, #154
ref https://github.com/projectblacklight/spotlight/pull/2313

Copied fix from Spotlight to our local app.  Sets permissions for exhibit admin so they can upload a file to serve as the masthead.