### PR TITLE
give exhibit admin permission to upload a file as the masthead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.1.0 (2020-03-30)
+
+* spotlight version updated to v1.5.1
+  * 5 database migrations
+  * many dependency updates
+* added spotlight version to footer
+* refactors documentation to use Jekyll documentation theme
+
 ### 1.0.1 (2020-03-10)
 
 * BUG FIX: patch s3 access to remove expiry token from attachment URLs

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -26,7 +26,7 @@ module Spotlight
         can :manage, [Spotlight::BlacklightConfiguration, Spotlight::ContactEmail], exhibit_id: user.admin_roles.pluck(:resource_id)
         can :manage, Spotlight::Role, resource_id: user.admin_roles.pluck(:resource_id), resource_type: 'Spotlight::Exhibit'
 
-        can :manage, PaperTrail::Version if user.roles.any?
+        can :manage, [PaperTrail::Version, Spotlight::FeaturedImage] if user.roles.any?
 
         # exhibit curator
         can :manage, [


### PR DESCRIPTION
fixes #282, #154
ref projectblacklight/spotlight#2313

Copied fix from Spotlight to our local app.  Sets permissions for exhibit admin so they can upload a file to serve as the masthead.