### PR TITLE
release exhibits v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.1 (2020-04-02)
+
+* BUG FIX: give exhibit admin permission to upload a file as the masthead
+
 ### 1.1.0 (2020-03-30)
 
 * spotlight version updated to v1.5.1

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -26,7 +26,7 @@ module Spotlight
         can :manage, [Spotlight::BlacklightConfiguration, Spotlight::ContactEmail], exhibit_id: user.admin_roles.pluck(:resource_id)
         can :manage, Spotlight::Role, resource_id: user.admin_roles.pluck(:resource_id), resource_type: 'Spotlight::Exhibit'
 
-        can :manage, PaperTrail::Version if user.roles.any?
+        can :manage, [PaperTrail::Version, Spotlight::FeaturedImage] if user.roles.any?
 
         # exhibit curator
         can :manage, [

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v1.1.0</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v1.1.1</small></p>
 		<p class="text-muted version"><small>Spotlight v1.5.1</small></p>
 	</div>
 </footer>


### PR DESCRIPTION
* BUG FIX: give exhibit admin permission to upload a file as the masthead
