### PR TITLE
release 2.4.2 - put pin of autoprefixer-rails and sprockets back in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+### 2.4.2 (2020-04-16)
+
+* put pin of autoprefixer-rails back in place
+* put pin of sprockets back in place
+
 ### 2.4.1 (2020-04-16)
 
-* spotlight version updated to v2.4.0
+* spotlight version updated to v2.4.1
   * validate the FeaturedImage object if provided
   * avoid using javascript keywords as variable names
 

--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,7 @@ group :test do
   # gem 'rspec-rails'
   # gem 'rspec-activemodel-mocks'
 end
+
+# tmp pins for incompatibilities
+gem 'autoprefixer-rails', '8.5.2' # ERROR: Autoprefixer doesn’t support Node v4.6.0 (only happens on AWS)
+gem 'sprockets', '3.7.2' # avoid err working with font-awesome 4.5 - corrected in 5.12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       rails (>= 4.2)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.7.6)
+    autoprefixer-rails (8.5.2)
       execjs
     aws-eventstream (1.0.1)
     aws-partitions (1.129.0)
@@ -478,6 +478,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails (= 8.5.2)
   better_errors
   binding_of_caller
   bixby (~> 1.0.0)
@@ -514,6 +515,7 @@ DEPENDENCIES
   sitemap_generator
   solr_wrapper (>= 0.3)
   spring
+  sprockets (= 3.7.2)
   sqlite3
   turbolinks (~> 5.2)
   tzinfo-data

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.4.1</small></p>
-		<p class="text-muted version"><small>Spotlight v2.4.1</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.4.2</small></p>
+		<p class="text-muted version"><small>Spotlight v2.4.2</small></p>
 	</div>
 </footer>


### PR DESCRIPTION
* avoid error: Autoprefixer doesn’t support Node v4.6.0 (only happens on AWS)
* avoid err working with font-awesome 4.5 - corrected in 5.12