### PR TITLE
v2.8.1 - display the header with a different background color for each env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.8.1 (2020-04-30)
+
+* display the header with a different background color for each Rails env
+
 ### 2.8.0 (2020-04-30)
 
 * add web accessibility assistance link in footer

--- a/app/assets/stylesheets/exhibits/_header.scss
+++ b/app/assets/stylesheets/exhibits/_header.scss
@@ -173,3 +173,17 @@ header {
 // 		// }
 // 	}
 // }
+
+// Header colors to identify Rails environment that is running
+header.staging_env {
+  background: #7aba7b; // light green
+}
+
+header.integration_env {
+  background: #a6e1ec; // pale blue
+}
+
+header.development_env {
+  background: #ebccd1; // pale pink
+}
+

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.8.0</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.8.1</small></p>
 		<p class="text-muted version"><small>Spotlight v2.8.0</small></p>
 	</div>
 </footer>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,3 +1,4 @@
+<% header_class = Rails.env == "production" ? "" : ' class=' + Rails.env + '_env' %>
 <!-- Cornell mobile header -->
 <div class="cornell-identity visible-xs">
   <div class="container">
@@ -9,7 +10,7 @@
   </div>
 </div>
 
-<header>
+<header<%= header_class %>>
   <div class="container">
     <div class="row">
       <div class="col-sm-8">


### PR DESCRIPTION
dev - pale red
int - pale blue
stg - light green

This makes it easier to know which environment is being testes at a glance.