### PR TITLE
release v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-### 2.14.0.alpha3 (2020-05-06)
+### 2.14.0 (2020-05-21)
 
 * use letter opener gem for testing email notifications in development environment
 * prevent add from CSV job from running again when email notification fails
 * minor adjustment to reset password notification to add source as CUL-Online Exhibits
 * adjust permissions for debug logger to allow writing
-
-### 2.13.5 (2020-05-06)
-
 * clean up environment variables and add examples
 
 ### 2.13.4 (2020-05-20)

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.14.0.alpha3</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.14.0</small></p>
 		<p class="text-muted version"><small>Spotlight v2.13.0</small></p>
 	</div>
 </footer>


### PR DESCRIPTION
### Change Log

#### 2.14.0

* adjust permissions for debug logger to allow writing
* minor adjustment to reset password notification
* prevent add from CSV job from re-running when email notification fails
* use letter opener for testing emails on dev
* clean up environment variables and add .env.example

#### 2.13.3

* skip exceptions when reindexing exhibits

#### 2.13.4

* move reindex override from prepend to full class override (required to catch problems in before_perform)
* make sidekiq logger statements write to production log (search for FAILURE to find indexing failures)