### PR TITLE
only show tabs for Add Item that are valid choices in our system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.14.1 (2020-05-21)
+
+* only show tabs for Add Item that are valid choices in our system
+
 ### 2.14.0 (2020-05-21)
 
 * use letter opener gem for testing email notifications in development environment

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.14.0</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.14.1.rc1</small></p>
 		<p class="text-muted version"><small>Spotlight v2.13.0</small></p>
 	</div>
 </footer>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -9,13 +9,14 @@
 
 # ==> Appearance configuration
 # Spotlight::Engine.config.exhibit_main_navigation = [:curated_features, :browse, :about]
-# Spotlight::Engine.config.resource_partials = [
+Spotlight::Engine.config.resource_partials = [
 #   'spotlight/resources/external_resources_form',
-#   'spotlight/resources/upload/form',
-#   'spotlight/resources/csv_upload/form',
+  'spotlight/resources/upload/form',
+  'spotlight/resources/csv_upload/form'
 #   'spotlight/resources/json_upload/form'
-# ]
-Spotlight::Engine.config.external_resources_partials = ["portal_resources/form"]
+#   'spotlight/resources/iiif/form'
+]
+# Spotlight::Engine.config.external_resources_partials = ["portal_resources/form"]
 # Spotlight::Engine.config.default_browse_index_view_type = :gallery
 # Spotlight::Engine.config.default_contact_email = nil
 


### PR DESCRIPTION
Only allowing users to choose Upload item or Upload multiple items.  All other options are hidden, at least for now.