### PR TITLE
Add SMTP configs for email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
+### 2.14.2 (2020-06-13)
+
+* set up environment variables for configuring action mailer in stg and prod environments
+* use letter opener gem for testing email notifications in int environment
+
 ### 2.14.1 (2020-05-21)
 
+* add examples directory holding example csv for multi-item upload
 * only show tabs for Add Item that are valid choices in our system
-* add example directory holding example csv for multi-item upload
 
 ### 2.14.0 (2020-05-21)
 
-* use letter opener gem for testing email notifications in development environment
+* use letter opener gem for testing email notifications in dev environment
 * prevent add from CSV job from running again when email notification fails
 * minor adjustment to reset password notification to add source as CUL-Online Exhibits
 * adjust permissions for debug logger to allow writing
@@ -13,8 +18,8 @@
 
 ### 2.13.4 (2020-05-20)
    
-* make sidekiq logger statements write to production log
 * override entire ReindexJob instead of prepend
+* make sidekiq logger statements write to production log
 * skip exceptions in perform_before block as well as perform method
   
 ### 2.13.3 (2020-05-20)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: ENV['EMAIL_FROM']
   layout 'mailer'
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.14.1.rc2</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.14.2.rc1</small></p>
 		<p class="text-muted version"><small>Spotlight v2.13.0</small></p>
 	</div>
 </footer>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,12 +26,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Open emails in a web browser
-  config.action_mailer.delivery_method = :letter_opener
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  # Configure Email Notifications
+  config.action_mailer.delivery_method = :letter_opener # Open emails in a web browser
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -55,11 +55,11 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "exhibits_#{Rails.env}"
-  config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Configure Email Notifications
+  config.action_mailer.delivery_method = :letter_opener # Open emails in a web browser
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_caching = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,11 +55,19 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "exhibits"
-  config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Configure Email Notifications
+  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = false # Not raising errors as it causes jobs to fail AND repeat for notification errors
+  config.action_mailer.smtp_settings = {
+      :address => ENV["SMTP_ADDRESS"],
+      :port => ENV["SMTP_PORT"],
+      :user_name => ENV["SMTP_USERNAME"],
+      :password => ENV["SMTP_PASSWORD"],
+      :authentication => :login,
+      :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,11 +55,19 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "exhibits_#{Rails.env}"
-  config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Configure Email Notifications
+  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+      :address => ENV["SMTP_ADDRESS"],
+      :port => ENV["SMTP_PORT"],
+      :user_name => ENV["SMTP_USERNAME"],
+      :password => ENV["SMTP_PASSWORD"],
+      :authentication => :login,
+      :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Fixes email notifications failing to be sent.

Setup action mailer specific to each environment
* dev and int use letter opener gem to display email in browser
* stg and prod send email through AWS’ SMS SMTP

Remaining Work:
* setup notifications@exhibits.library.cornell.edu and notifications-stg@exhibits.library.cornell.edu
* update env configs to use those as FROM_EMAIL in prod and stg envs, respectively