### PR TITLE
Do not use letter-opener for integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-### 2.14.2 (2020-06-13)
+### 2.15.0 (2020-06-16)
 
 * update dependencies to address security vulnerabilities - kaminari, websockets-extensions
 * set up environment variables for configuring action mailer in stg and prod environments
-* use letter opener gem for testing email notifications in int environment
 
 ### 2.14.1 (2020-05-21)
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,16 +50,16 @@ end
 group :development do
   gem 'better_errors' # add command line in browser when errors
   gem 'binding_of_caller' # deeper stack trace used by better errors
+  gem 'letter_opener' # show emails in browser
   gem 'solr_wrapper', '>= 0.3' # start solr based on .solr_wrapper.yml
-  gem 'web-console', '~> 3.0' # access to IRB console on exception pages
 
   # gem 'spring-watcher-listen', '~> 2.0.0' # makes Spring watch filesystem for changes using Listen rather than polling
 end
 
 group :development, :integration do
-  gem 'letter_opener'
   gem 'spring' # Spring speeds up development by keeping your application running in the background.
   gem 'xray-rails' # overlay showing which files are contributing to the UI
+  gem 'web-console', '~> 3.0' # access to IRB console on exception pages
 end
 
 group :development, :test do

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
 		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits v2.14.2.rc3</small></p>
+		<p class="text-muted version"><small>Cornell Exhibits v2.15.0.rc1</small></p>
 		<p class="text-muted version"><small>Spotlight v2.13.0</small></p>
 	</div>
 </footer>

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -57,9 +57,17 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "exhibits_#{Rails.env}"
 
   # Configure Email Notifications
-  config.action_mailer.delivery_method = :letter_opener # Open emails in a web browser
-  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+      :address => ENV["SMTP_ADDRESS"],
+      :port => ENV["SMTP_PORT"],
+      :user_name => ENV["SMTP_USERNAME"],
+      :password => ENV["SMTP_PASSWORD"],
+      :authentication => :login,
+      :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Letter opener gem does not support remote servers.  It tries to open a browser window on the remote server and show the email at a localhost URL.  This doesn’t work on AWS servers.