### PR TITLE
release v2.17.2 - display 4 exhibits per row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.17.2 (2020-08-06)
 
 * display 4 exhibits per row when no sidebar
+* in right side menu, do not show users actions they cannot perform
 
 ### 2.17.1 (2020-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.17.2 (2020-08-06)
+
+* display 4 exhibits per row when no sidebar
+
 ### 2.17.1 (2020-08-06)
 
 * cleanup comments for v2.17 - no code changes

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -1,22 +1,16 @@
 <% if can?(:manage, Spotlight::Site.instance) || can?(:create, Spotlight::Exhibit) %>
 <h4 class="nav-heading"><%=t(:'.header') %></h4>
 <ul class="nav sidenav">
-  <li><%= link_to t('.documentation'), 'https://github.com/projectblacklight/spotlight/wiki/Configuration-settings' %></li>
-
   <% if can? :manage, Spotlight::Site.instance %>
+    <% # BEGIN CUSTOMIZATION elr - Limit right side bar actions to site admins only %>
+    <li><%= link_to t('.documentation'), 'https://github.com/projectblacklight/spotlight/wiki/Configuration-settings' %></li>
     <li><%= link_to t(:'spotlight.sites.edit.page_title'), spotlight.edit_site_path %></li>
-  <% end %>
-
-  <% if can? :manange, Spotlight::Exhibit %>
     <li><%= link_to t(:'spotlight.sites.edit_exhibits.page_title'), spotlight.edit_site_exhibits_path %></li>
     <li><%= link_to t(:'spotlight.admin_users.index.page_title'), spotlight.admin_users_path %></li>
-  <% end %>
 
-  <% # BEGIN CUSTOMIZATION elr - add System Check to right side bar for site admins %>
-  <% if can? :manage, Spotlight::Site.instance %>
     <li><%= link_to t(:'okcomputer.system_check'), File.join(ok_computer_path, 'all') %></li>
+    <% # END CUSTOMIZATION %>
   <% end %>
-  <% # END CUSTOMIZATION %>
 </ul>
 
 <ul class="nav sidenav nav-pills nav-stacked">

--- a/app/views/spotlight/exhibits/_exhibits.html.erb
+++ b/app/views/spotlight/exhibits/_exhibits.html.erb
@@ -1,0 +1,13 @@
+<% # BEGIN CUSTOMIZATION elr - show 3 exhibit per row when there is a sidebar; otherwise, show 4 %>
+<% if can?(:manage, Spotlight::Exhibit) %>
+  <% exhibits_per_row = 3 %>
+<% else %>
+  <% exhibits_per_row = 4 %>
+<% end %>
+
+<% exhibits.each_slice(exhibits_per_row).each do |row| %>
+<% # END CUSTOMIZATION %>
+  <div class="row"><!-- start main content row -->
+    <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
+  </div>
+<% end %>

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,0 +1,57 @@
+<% # BEGIN CUSTOMIZATION elr - use 9 columns when there will be a sidebar; otherwise, 12 columns %>
+  <% if can?(:manage, Spotlight::Exhibit) %>
+<div class="col-md-9">
+  <% else %>
+<div class="col-md-12">
+  <% end %>
+<% # END CUSTOMIZATION %>
+
+  <% if (current_user && current_user.exhibits.any?) || can?(:manage, Spotlight::Exhibit) %>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a href="#published" aria-controls="published" role="tab" data-toggle="tab"><%= t('.published') %></a></li>
+      <% if can?(:manage, Spotlight::Exhibit) && @exhibits.unpublished.accessible_by(current_ability).any? %>
+        <li role="presentation"><a href="#unpublished" aria-controls="unpublished" role="tab" data-toggle="tab"><%= t('.unpublished') %></a></li>
+      <% end %>
+      <% if current_user && current_user.exhibits.any? %>
+        <li role="presentation"><a href="#user" aria-controls="user" role="tab" data-toggle="tab"><%= t('.user') %></a></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="published">
+      <% if @exhibits.published.none? %>
+        <%= render 'missing_exhibits' %>
+      <% else %>
+        <%= render 'tags', tags: @exhibits.published.all_tags %>
+        <%= render 'exhibits', exhibits: @published_exhibits %>
+
+        <% if @published_exhibits.total_count > @published_exhibits.size %>
+          <nav>
+            <ul class="pager">
+              <li><%= link_to_previous_page @published_exhibits, t('views.pagination.previous').html_safe %></li>
+              <li><%= link_to_next_page @published_exhibits, t('views.pagination.next').html_safe %></li>
+            </ul>
+          </nav>
+        <% end %>
+      <% end %>
+
+    </div>
+
+    <% if @exhibits.unpublished.accessible_by(current_ability).any? %>
+      <div role="tabpanel" class="tab-pane" id="unpublished">
+        <%= render 'exhibits', exhibits: @exhibits.unpublished.ordered_by_weight.accessible_by(current_ability) %>
+      </div>
+    <% end %>
+
+    <% if current_user && current_user.exhibits.any? %>
+      <div role="tabpanel" class="tab-pane" id="user">
+        <%= render 'exhibits', exhibits: current_user.exhibits %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<aside class="col-md-3">
+  <%= render "shared/site_sidebar" %>
+</aside>

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.2.rc2".freeze
+  VERSION = "v2.17.2.rc3".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.2.rc3".freeze
+  VERSION = "v2.17.2".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.1".freeze
+  VERSION = "v2.17.2.rc2".freeze
 end


### PR DESCRIPTION
Change Log:

* display 4 exhibits per row when no sidebar
* in right side menu, do not show users actions they cannot perform
