### PR TITLE
Release v2.17.4 - move login to footer and remove links in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * move login to footer
 * remove extra links from header for public users
+* set the color for create exhibit button to make it easier to see
 
 ### 2.17.3 (2020-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.17.4 (2020-08-06)
+
+* move login to footer
+* remove extra links from header for public users
+
 ### 2.17.3 (2020-08-06)
 
 * limit privileges of administrators to creating exhibits

--- a/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
@@ -1,0 +1,3 @@
+.btn-nav {
+  background-color: #e1efc6;
+}

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,57 @@
+<div class="navbar-right">
+
+  <ul class="nav navbar-nav">
+    <% # BEGIN CUSTOMIZATION elr - only show header links to logged in users %>
+    <% if current_user %>
+      <%= render_nav_actions do |config, action|%>
+        <li><%= action %></li>
+      <% end %>
+    <% end %>
+    <% # END CUSTOMIZATION %>
+  </ul>
+
+  <ul class="nav navbar-nav">
+    <%= render '/spotlight/shared/locale_picker' %>
+    <% if current_user %>
+      <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=current_user%> <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <% if can? :manage, Spotlight::Site.instance %>
+            <li><%= link_to t(:'spotlight.header_links.edit_site'), spotlight.edit_site_path %></li>
+          <% end %>
+          <% if can? :create, Spotlight::Exhibit %>
+            <li>
+              <%= link_to t(:'spotlight.header_links.create_exhibit'), spotlight.new_exhibit_path %>
+            </li>
+            <li class="divider"></li>
+          <% end %>
+          <% if current_exhibit && can?(:curate, current_exhibit) %>
+            <li>
+              <%= link_to t('spotlight.header_links.dashboard'), spotlight.exhibit_dashboard_path(current_exhibit) %>
+            </li>
+            <li class="divider"></li>
+          <% end %>
+
+          <li>
+            <%= link_to "Change Password", main_app.edit_user_registration_path %>
+          </li>
+          <li>
+            <%= link_to t('spotlight.header_links.logout'), main_app.destroy_user_session_path %>
+          </li>
+        </ul>
+      </li>
+    <% # BEGIN CUSTOMIZATION elr - remove login link from header (see footer for new location) %>
+    <% # else % >
+       # <li>
+       #   < %= link_to t('spotlight.header_links.login'), main_app.new_user_session_path % >
+       # </li>
+    %>
+    <% # END CUSTOMIZATION %>
+    <% end %>
+    <% if current_exhibit and show_contact_form? %>
+      <li>
+        <%= link_to t('spotlight.header_links.contact'), spotlight.new_exhibit_contact_form_path(current_exhibit), data: {behavior: 'contact-link', target: 'report-problem-form' } %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,16 @@
 <% require 'version' %>
 <footer>
-	<div class="container">
-		<p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
-		<p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
-		<p class="text-muted version"><small>Cornell Exhibits <%= Version::VERSION %>></small></p>
-		<p class="text-muted version"><small>Spotlight <%= SPOTLIGHT_VERSION %></small></p>
-	</div>
+  <div class="container">
+    <div class="col-sm-10">
+      <p>©2020 Cornell University Library / (607) 255-4144 / <a href="http://www.library.cornell.edu/privacy">Privacy</a> / <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
+      <p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/">Spotlight help</a></small></p>
+      <p class="text-muted version"><small>Cornell Exhibits <%= Version::VERSION %>></small></p>
+      <p class="text-muted version"><small>Spotlight <%= SPOTLIGHT_VERSION %></small></p>
+    </div>
+    <div class="col-sm-2">
+      <% unless current_user %>
+        <p><%= link_to t('spotlight.header_links.login'), main_app.new_user_session_path %></p>
+      <% end %>
+    </div>
+  </div>
 </footer>

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.4.rc1".freeze
+  VERSION = "v2.17.4.rc2".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.3".freeze
+  VERSION = "v2.17.4.rc1".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.4.rc2".freeze
+  VERSION = "v2.17.4".freeze
 end


### PR DESCRIPTION
* move login to footer
* remove extra links from header for public users
* set the color for create exhibit button to make it easier to see
