### PR TITLE
change label to ‘Remove from exhibit’ when removing user from an exhibit

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -7,3 +7,7 @@ en:
         confirm: Confirm my account
     header_links:
       login: Admin Login
+  helpers:
+    action:
+      spotlight/role:
+        destroy: Remove from exhibit


### PR DESCRIPTION
Fixes: Issue #373 Use 'Remove from exhibit' instead of 'Remove from site' on Exhibit Dashboard's user list