### PR TITLE
release 2.17.12 - show sidebar for all logged in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.17.12 (2020-11-20)
+
+* show at least documentation links in sidebar for all logged in users
+
 ### 2.17.11 (2020-11-20)
 
 * add analytics dashboard

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,5 +1,5 @@
 <% # BEGIN CUSTOMIZATION elr - use 9 columns when there will be a sidebar; otherwise, 12 columns %>
-  <% if can?(:create, Spotlight::Exhibit) %>
+  <% if current_user # all logged in users see at least documentation links %>
 <div class="col-md-9">
   <% else %>
 <div class="col-md-12">

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.11".freeze
+  VERSION = "v2.17.12".freeze
 end


### PR DESCRIPTION
Sidebar was updated to minimally show documentation links for all logged in users.  But the flow of exhibits was 4-across unless the user could create exhibits.  This fixes the flow to 3-across for all logged in users.  It sill flows 4-across when not logged in.