### PR TITLE
limit tag to curated set on New Exhibit form

### DIFF
--- a/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
+++ b/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
@@ -1,0 +1,18 @@
+<%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
+<div class="row col-md-12">
+  <%= f.text_field :title, label: t(:'.fields.title.label'), help: t(:'.fields.title.help_block') %>
+  <%= f.text_field :slug, label: t(:'.fields.slug.label'), help: t(:'.fields.slug.help_block') %>
+
+  <% # BEGIN CUSTOMIZATION elr - restrict exhibit tags to controlled list %>
+  <%= f.select(:tag_list, TagListService.tag_list, {}, { :multiple => true }) %>
+  <% # END CUSTOMIZATION %>
+
+  <%= render 'initial_resources_form', locals: { f: f } %>
+
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+</div>
+<% end %>


### PR DESCRIPTION
Fixes #372

Related to PR #367 which limited the tags on the Edit form in the exhibit dashboard