### PR TITLE
remove support for the video widget

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -69,8 +69,8 @@ Spotlight::Engine.config.uploader_storage = :aws if ENV['S3_KEY_ID'].present?
 # Spotlight::Engine.config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)
 
 # ==> Sir Trevor Widget Configuration
-# Spotlight::Engine.config.sir_trevor_widgets = %w(
-#   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse
-#   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
-#   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
-# )
+Spotlight::Engine.config.sir_trevor_widgets = %w[
+  Heading Text List Quote Iframe Oembed Rule UploadedItems Browse LinkToSearch
+  FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
+  SolrDocumentsFeatures SolrDocumentsGrid SearchResults
+]


### PR DESCRIPTION
Fixes #147

Uploading videos through the video widget generally does not work and leaves the page in a corrupt state requiring manual intervention to repair. See Issue #147 which describes the manual process and requests removal of the video widget.

_NOTE: Documentation needs to be added to describe the alternate approach using Embed + Text or Iframe Embed._
