### PR TITLE
release 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.0 (2021-02-01)
+
+* revert removal of video widget - caused problems with previously uploaded videos
+
 ### 2.18.0 (2021-01-28)
 
 * remove support for video widget

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -70,7 +70,7 @@ Spotlight::Engine.config.uploader_storage = :aws if ENV['S3_KEY_ID'].present?
 
 # ==> Sir Trevor Widget Configuration
 Spotlight::Engine.config.sir_trevor_widgets = %w[
-  Heading Text List Quote Iframe Oembed Rule UploadedItems Browse LinkToSearch
+  Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse LinkToSearch
   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
 ]

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.18.0".freeze
+  VERSION = "v2.19.0".freeze
 end


### PR DESCRIPTION
revert removal of video widget

Without the video widget enabled, editing a page that already has a video caused the video to be removed.  Our goal was to prevent upload of new videos through the video widget.

Have to revert for now to come up with a better long term approach.