### PR TITLE
release 2.19.0 - revert removal of video widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 2.18.0 (2021-01-28)
+
+* remove support for video widget
+* add documentation for heading, text, list, quote, and hr widgets
+* update dependencies
+* add CircleCI as continuous integration testing in GitHub
+* add Docker configs for local and CCI testing (experimental for use in browser)
+* add first test to simply test that users can login
+* limit tag to curated set on New Exhibit form
+* use exhibit creator language instead of administrator
+
 ### 2.17.12 (2020-11-20)
 
 * show at least documentation links in sidebar for all logged in users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.0 (2021-02-01)
+
+* revert removal of video widget - caused problems with previously uploaded videos
+
 ### 2.18.0 (2021-01-28)
 
 * remove support for video widget

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -70,7 +70,7 @@ Spotlight::Engine.config.uploader_storage = :aws if ENV['S3_KEY_ID'].present?
 
 # ==> Sir Trevor Widget Configuration
 Spotlight::Engine.config.sir_trevor_widgets = %w[
-  Heading Text List Quote Iframe Oembed Rule UploadedItems Browse LinkToSearch
+  Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse LinkToSearch
   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
 ]

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.18.0".freeze
+  VERSION = "v2.19.0".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.17.12".freeze
+  VERSION = "v2.18.0".freeze
 end


### PR DESCRIPTION
Revert removal of video widget

Without the video widget enabled, editing a page that already has a video caused the video to be removed.  Our goal was to prevent upload of new videos through the video widget.

Reverting for now until we come up with a better long term approach.