### PR TITLE
Release v2.20.0 - default to utf8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.20.0 (2021-02-11)
+
+* update production database tables to use utf8 allowing for internationalization
+
 ### 2.19.1 (2021-02-08)
 
 * fix fails to skip reindex error due to misspelling of exhibit_or_resources variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.1 (2021-02-08)
+
+* fix fails to skip reindex error due to misspelling of exhibit_or_resources variable
+
 ### 2.19.0 (2021-02-01)
 
 * revert removal of video widget - caused problems with previously uploaded videos

--- a/app/jobs/spotlight/reindex_job.rb
+++ b/app/jobs/spotlight/reindex_job.rb
@@ -62,10 +62,10 @@ module Spotlight
         begin
           resource.reindex(log_entry)
         rescue Exception => e # rubocop:disable Lint/RescueException
-          skipped = skip_perform_exceptions(exhibit_or_resoruces) ? "SKIPPING " : ""
+          skipped = skip_perform_exceptions(exhibit_or_resources) ? "SKIPPING " : ""
           logger.warn("#{skipped}RESOURCE REINDEX FAILURE: Exception reindexing resource #{resource.id} in exhibit " \
                       "#{resource.exhibit_id} with upload_id #{resource.upload_id}.  Cause: #{e.class}: #{e.message}")
-          raise e unless skip_perform_exceptions(exhibit_or_resoruces)
+          raise e unless skip_perform_exceptions(exhibit_or_resources)
         end
         # END CUSTOMIZATION
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20200430195754) do
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "friendly_id_slugs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "friendly_id_slugs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "spotlight_attachments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_attachments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.string "file"
     t.string "uid"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.datetime "updated_at"
   end
 
-  create_table "spotlight_blacklight_configurations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_blacklight_configurations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "exhibit_id"
     t.text "facet_fields"
     t.text "index_fields"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.datetime "updated_at"
   end
 
-  create_table "spotlight_contact_emails", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_contact_emails", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "exhibit_id"
     t.string "email", default: "", null: false
     t.string "confirmation_token"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["email", "exhibit_id"], name: "index_spotlight_contact_emails_on_email_and_exhibit_id", unique: true
   end
 
-  create_table "spotlight_contacts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_contacts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "slug"
     t.string "name"
     t.string "email"
@@ -108,7 +108,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["exhibit_id"], name: "index_spotlight_contacts_on_exhibit_id"
   end
 
-  create_table "spotlight_custom_fields", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_custom_fields", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "exhibit_id"
     t.string "slug"
     t.string "field"
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["exhibit_id"], name: "index_spotlight_custom_search_fields_on_exhibit_id"
   end
 
-  create_table "spotlight_exhibits", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_exhibits", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title", null: false
     t.string "subtitle"
     t.string "slug"
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["slug"], name: "index_spotlight_exhibits_on_slug", unique: true
   end
 
-  create_table "spotlight_featured_images", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_featured_images", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "type"
     t.boolean "display"
     t.string "image"
@@ -169,7 +169,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.string "iiif_tilesource"
   end
 
-  create_table "spotlight_filters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_filters", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "field"
     t.string "value"
     t.integer "exhibit_id"
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["exhibit_id"], name: "index_spotlight_languages_on_exhibit_id"
   end
 
-  create_table "spotlight_locks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_locks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "on_type"
     t.integer "on_id"
     t.string "by_type"
@@ -198,7 +198,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["on_id", "on_type"], name: "index_spotlight_locks_on_on_id_and_on_type", unique: true
   end
 
-  create_table "spotlight_main_navigations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_main_navigations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "label"
     t.integer "weight", default: 20
     t.string "nav_type"
@@ -209,7 +209,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["exhibit_id"], name: "index_spotlight_main_navigations_on_exhibit_id"
   end
 
-  create_table "spotlight_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.string "type"
     t.string "slug"
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["slug", "scope"], name: "index_spotlight_pages_on_slug_and_scope", unique: true
   end
 
-  create_table "spotlight_reindexing_log_entries", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_reindexing_log_entries", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "items_reindexed_count"
     t.integer "items_reindexed_estimate"
     t.datetime "start_time"
@@ -248,7 +248,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.datetime "updated_at"
   end
 
-  create_table "spotlight_resources", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_resources", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "exhibit_id"
     t.string "type"
     t.string "url"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["upload_id"], name: "index_spotlight_resources_on_upload_id"
   end
 
-  create_table "spotlight_roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.string "role"
     t.integer "resource_id"
@@ -273,7 +273,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["resource_type", "resource_id", "user_id"], name: "index_spotlight_roles_on_resource_and_user_id", unique: true
   end
 
-  create_table "spotlight_searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.string "slug"
     t.string "scope"
@@ -294,13 +294,13 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["slug", "scope"], name: "index_spotlight_searches_on_slug_and_scope", unique: true
   end
 
-  create_table "spotlight_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_sites", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.string "subtitle"
     t.integer "masthead_id"
   end
 
-  create_table "spotlight_solr_document_sidecars", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "spotlight_solr_document_sidecars", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "exhibit_id"
     t.boolean "public", default: true
     t.text "data"
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["resource_type", "resource_id"], name: "spotlight_solr_document_sidecars_resource"
   end
 
-  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
     t.string "taggable_type"
@@ -337,7 +337,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", collation: "utf8_bin"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true
@@ -356,7 +356,7 @@ ActiveRecord::Schema.define(version: 20200430195754) do
     t.index ["exhibit_id"], name: "index_translations_on_exhibit_id"
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.19.1".freeze
+  VERSION = "v2.20.0".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v2.19.0".freeze
+  VERSION = "v2.19.1".freeze
 end


### PR DESCRIPTION
Allows for text with diacritics.

Database tables on production updated to have utf8 encoding and utf8_general_ci collation.