### PR TITLE
wrap image and title in the same link on home page

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,0 +1,41 @@
+<% ### REMOVE THIS FILE WHEN Spotlight PR #2768 is merged. %>
+<div class="col mb-4">
+  <% ### BEGIN CUSTOMIZATION elr - FIX Site Improve Error: Image link is missing alternative text - moves link to cover image and title as a single link %>
+  <%= link_to exhibit, tabindex: '-1' do %>
+    <div class="card exhibit-card">
+      <% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
+        <%= image_tag(exhibit.thumbnail.iiif_url, class: 'card-img',  alt: '', role: 'presentation', skip_pipeline: true, aria: { hidden: true  }) %>
+      <% else %>
+        <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'card-img default-thumbnail',  alt: '', role: 'presentation', aria: { hidden: true  } %>
+      <% end %>
+      <div class="card-img-overlay pb-0">
+        <% unless exhibit.published? %>
+          <div class="badge badge-warning unpublished"><%= t('.unpublished') %></div>
+        <% end %>
+
+        <%= content_tag :h2, class: 'card-title h5 text-center', aria: { describedby: "exhibit-description-#{exhibit.to_param}" } do %>
+          <span><%= exhibit.title %></span>
+        <% end %>
+
+        <% ### BEGIN CUSTOMIZATION elr - no actual changes here other than indentation" %>
+        <% if exhibit.subtitle || exhibit.description  %>
+          <%= content_tag :div, id: "exhibit-description-#{exhibit.to_param}", class: 'card-text exhibit-description' do %>
+            <% if exhibit.subtitle %>
+              <p class="subtitle">
+                <%= exhibit.subtitle %>
+              </p>
+            <% end %>
+
+            <% if exhibit.description %>
+              <p class="description">
+                <%= exhibit.description %>
+              </p>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% ### END indentation only CUSTOMIZATION %>
+      </div>
+    </div>
+  <% end %>
+  <% ### END CUSTOMIZATION %>
+</div>


### PR DESCRIPTION
Customization to fix SiteImprove error on Home Page.

```
Image link is missing alternative text
A 2.4.4 Link Purpose (In Context)
```

[Spotlight PR #2768](https://github.com/projectblacklight/spotlight/pull/2768) proposes the same fix in Spotlight.  Once this is merged, the local customization added in this PR can be deleted.

Issue #481 Tracks the merge of the Spotlight PR and the need to delete local changes.