### PR TITLE
include <h1> tag on all non-exhibit pages

### DIFF
--- a/app/assets/stylesheets/exhibits/_header.scss
+++ b/app/assets/stylesheets/exhibits/_header.scss
@@ -91,6 +91,7 @@ header {
 }
 
 .site-title-brand {
+    max-height: 60px;
 	padding: .5rem;
 	font-size: 1.8rem;
 	text-transform: uppercase;

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -55,7 +55,11 @@
 <nav class="site-nav">
   <div class="<%= container_classes %>">
     <div class="site-title-brand">
-      <a href="/"><%= I18n.t(:'blacklight.application_name') %></a>
+      <% unless current_exhibit # Addresses accessibility missing <h1> on non-exhibit pages %>
+        <h1 class="site-title-brand"><a href="/"><%= I18n.t(:'blacklight.application_name') %></a></h1>
+      <% else %>
+        <a href="/"><%= I18n.t(:'blacklight.application_name') %></a>
+      <% end %>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
Fixes Accessibility Error:

```
No top-level heading on the page
A 1.3.1 Info and Relationships
```