### PR TITLE
For accessibility, allow aria-label and title in iFrames

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_iframe_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_iframe_block.html.erb
@@ -1,0 +1,1 @@
+<%= sanitize iframe_block.code, tags: %w(iframe), attributes: %w(id aria-label title width height marginwidth marginheight src frameborder allowfullscreen sandbox seamless srcdoc scrolling) %>


### PR DESCRIPTION
Remove customization when [Spotlight PR #2774](https://github.com/projectblacklight/spotlight/pull/2774) is merged.

### Solution

Allow aria-label and title in iFrames to allow curators to fix iFrame accessibility errors.

NOTE: This provides the curator with the ability to fix their content by adding a title.  The step to add the title is a manual process and will need to be performed for any iFrame that does not already have a title or an aria-label included.

### Error

![image](https://user-images.githubusercontent.com/6855473/128539065-99c5fbfb-4def-4254-825f-b127ad4c14c0.png)

![image](https://user-images.githubusercontent.com/6855473/128539170-57223995-b94a-4d4b-976d-0ed143f79d7a.png)