### PR TITLE
Accessibility: Fix previous and next text and aria-labels

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,18 @@
 en:
   blacklight:
     application_name: 'Online Exhibitions'
+  views:
+    pagination:
+      first: 'First'
+      last: 'Last'
+      previous: 'Previous'
+      next: 'Next'
+      truncate: '…'
+      aria:
+        container_label: 'pagination links'
+        current_page: 'Current Page, Page %{page}'
+        go_to_page: 'Go to page %{page}'
+        go_to_previous_page: 'Previous page'
+        go_to_next_page: 'Next page'
+        go_to_first_page: 'First page'
+        go_to_last_page: 'Last page'


### PR DESCRIPTION
Fixes complaint that aria-label does not match link text.

![image](https://user-images.githubusercontent.com/6855473/128554925-31d302e7-81bf-4e3a-a7cd-0e2eb5f2c693.png)
