### PR TITLE
make underlining of links apply to all sir treavor blocks

### DIFF
--- a/app/assets/stylesheets/exhibits/_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_blocks.scss
@@ -4,6 +4,7 @@
 	padding: 5px 0;
 }
 
-.st__content-block--text a {
+.content-block a,
+.st__content-block a {
   text-decoration: underline;
 }


### PR DESCRIPTION
Related work: PR #485

Fixes accessibility error: 

![image](https://user-images.githubusercontent.com/6855473/128557707-fef9a85f-594b-4b45-b9e8-c33e32219154.png)

### Impacts

This error impacts...
* 68 pages
* 230 occurrences

Fixing will increase score by 1.17 points