### PR TITLE
adding copyright field for app with i18n string

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -38,6 +38,27 @@ Spotlight::Engine.config.resource_partials = [
 # Spotlight::Engine.config.full_image_field = :full_image_url_ssm
 # Spotlight::Engine.config.thumbnail_field = :thumbnail_url_ssm
 
+# ==> Adding copyright to default configuration.  Note "UploadFieldConfig" needs to be preceded by "Spotlight::".  
+# Refer to https://github.com/projectblacklight/spotlight/blob/v3.3.0/lib/spotlight/engine.rb
+Spotlight::Engine.config.upload_fields = [
+  Spotlight::UploadFieldConfig.new(
+     field_name: Spotlight::Engine.config.upload_description_field,
+     label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.upload_description_field}") },
+     form_field_type: :text_area
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_upload_attribution_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_upload_date_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_copyright_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_copyright_tesim') }
+   )
+ ]
 # ==> Uploaded item configuration
 # Spotlight::Engine.config.upload_fields = [
 #   UploadFieldConfig.new(

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -13,6 +13,9 @@ en:
         destroy: Remove from exhibit creator role
         instructions: Existing exhibit creators
         update: Make user an exhibit creator
+    search:
+      fields:
+        spotlight_copyright_tesim: Copyright
   shared:
     site_sidebar:
       documentation: Spotlight curator documentation


### PR DESCRIPTION
Updated the Spotlight initializer to add to the list of default fields for an item.  Also added text to the spotlight.en.yml file to designate the label for the copyright field. 