### PR TITLE
add copyright link to footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
     <div class="col-sm-10">
-      <p>©2021 Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
+      <p><a href="https://www.library.cornell.edu/copyright">©2021</a> Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
       <% if current_user %>
       <p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/"><%= t(:'local_documentation') %></a></small></p>
       <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
     <div class="col-sm-10">
-      <p><a href="https://www.library.cornell.edu/copyright">©2021</a> Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
+      <p><a href="https://www.library.cornell.edu/copyright">©<%= Time.zone.now.year %></a> Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
       <% if current_user %>
       <p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/"><%= t(:'local_documentation') %></a></small></p>
       <% end %>


### PR DESCRIPTION
Add link to footer (where it says "(c) 2021") which goes to https://www.library.cornell.edu/copyright.  Linked to #585 