### PR TITLE
Show pages for item

### DIFF
--- a/app/assets/javascripts/relatedPages.js
+++ b/app/assets/javascripts/relatedPages.js
@@ -11,7 +11,7 @@ var relatedPages = {
     },
     requestPages:function(rootUrl, exhibitSlug, docid) {
       //Do an AJAX request for this exhibit
-      var url = rootUrl + exhibitSlug + "/tempages?item=" + docid;
+      var url = rootUrl + exhibitSlug + "/itempages?item=" + docid;
       $.ajax({
         url : url,
         success: function(data) {

--- a/app/assets/javascripts/relatedPages.js
+++ b/app/assets/javascripts/relatedPages.js
@@ -1,0 +1,43 @@
+var relatedPages = {
+    onLoad:function() {
+        //Get current exhibit URL and item id and pass to method
+        var relatedPagesDiv = $("#related-pages");
+        var exhibitSlug = relatedPagesDiv.attr("exhibitslug");
+        var rootUrl = relatedPagesDiv.attr("rooturl");
+        var docid = relatedPagesDiv.attr("docid");
+        if(exhibitSlug != "" && docid != "" && rootUrl != "") {
+          relatedPages.requestPages(rootUrl, exhibitSlug, docid);
+        }
+    },
+    requestPages:function(rootUrl, exhibitSlug, docid) {
+      //Do an AJAX request for this exhibit
+      var url = rootUrl + exhibitSlug + "/tempages?item=" + docid;
+      $.ajax({
+        url : url,
+        success: function(data) {
+          console.log(data);
+          if((data != null) && ("results" in data) && ("pages" in data["results"]) && (data["results"]["pages"].length > 0)) {
+            var pages = data["results"]["pages"];
+            var pageList = "";
+            var pageTitles = [];
+            $.each(pages, function(i, v) {
+              if("title" in v) {
+                pageTitles.push(v["title"]);
+              }
+            });
+            $("#related-pages").html("This item is used on the following pages: " + pageTitles.join(", "));
+          }
+        },
+        error: function(xhr, status, error) {
+          console.log("Error occurred retrieving page list for " + exhibitSlug + " and item " + docid);
+          console.log(xhr.status + ":" + xhr.statusText + ":" + xhr.responseText);
+        }
+      });
+    }
+};
+
+Blacklight.onLoad(function() {
+    if ( $("#related-pages").length > 0) {
+      relatedPages.onLoad();
+    }
+  });

--- a/app/assets/javascripts/relatedPages.js
+++ b/app/assets/javascripts/relatedPages.js
@@ -20,7 +20,7 @@ var relatedPages = {
             var pages = data["results"]["pages"];
             var pageTitles = [];
             $.each(pages, function(i, v) {
-              pageTitles.push(requestPages.generatePageLink(v, rootUrl, exhibitSlug));
+              pageTitles.push(relatedPages.generatePageLink(v, rootUrl, exhibitSlug));
             });
             $("#related-pages").html("This item is used on the following pages: " + pageTitles.join(", "));
           }

--- a/app/assets/javascripts/relatedPages.js
+++ b/app/assets/javascripts/relatedPages.js
@@ -18,12 +18,9 @@ var relatedPages = {
           console.log(data);
           if((data != null) && ("results" in data) && ("pages" in data["results"]) && (data["results"]["pages"].length > 0)) {
             var pages = data["results"]["pages"];
-            var pageList = "";
             var pageTitles = [];
             $.each(pages, function(i, v) {
-              if("title" in v) {
-                pageTitles.push(v["title"]);
-              }
+              pageTitles.push(requestPages.generatePageLink(v, rootUrl, exhibitSlug));
             });
             $("#related-pages").html("This item is used on the following pages: " + pageTitles.join(", "));
           }
@@ -33,6 +30,18 @@ var relatedPages = {
           console.log(xhr.status + ":" + xhr.statusText + ":" + xhr.responseText);
         }
       });
+    },
+    generatePageLink(pageObject, rootUrl, exhibitSlug) {
+      var title = pageObject["title"];
+      var pageSlug = pageObject["slug"];
+      var pageType = pageObject["pagetype"];
+      var pageURL = rootUrl + exhibitSlug;
+      if(pageType == "about") {
+        pageURL += "/about/" + pageSlug;
+      } else if(pageType == "feature") {
+        pageURL += "/feature/" + pageSlug;
+      }
+      return "<a href='" + pageURL + "'>" + title + "</a>";
     }
 };
 

--- a/app/controllers/spotlight/itempages_controller.rb
+++ b/app/controllers/spotlight/itempages_controller.rb
@@ -1,0 +1,53 @@
+module Spotlight
+  class ItempagesController < Spotlight::ApplicationController
+    # We want this request to be fully open since this information needs to be visible to users viewing the exhibit
+    def item_pages
+      item_id = params[:item] || ""
+      pages_json = JSON.parse(current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]))
+      exhibit_id = current_exhibit.id
+      result_array = parse_pages(pages_json, item_id, exhibit_id)
+      # Now get the information
+      render json: { "results" => result_array }.to_json
+    end
+
+    def parse_pages(pages_json, item_id, exhibit_id)
+      result_array = []
+      pages_json.each do |page|
+        page_id = page["id"]
+        title = page["title"]
+        slug = page["slug"]
+        if page["content"].length.positive? && !page["content"].empty?
+          content = page["content"]
+          result_array.concat parse_page_content(content, item_id, page_id, title, slug)
+        end
+      end
+      { "exhibit_id" => exhibit_id, "pages" => result_array }
+    end
+
+    def parse_page_content(content, item_id, page_id, title, slug)
+      result_array = []
+      content.each do |cont|
+        next unless cont.key?("data") && cont["data"].key?("item") && cont["data"]["item"].keys.length
+        item = cont["data"]["item"]
+        item.each do |_, v|
+          if v["id"] == item_id
+            page_type = get_page_type(page_id)
+            result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug, "pagetype" => page_type })
+          end
+        end
+      end
+      result_array
+    end
+
+    def get_page_type(page_id)
+      page_obj = current_exhibit.pages.find(page_id)
+      page_type = "home"
+      if page_obj.about_page?
+        page_type = "about"
+      elsif page_obj.feature_page?
+        page_type = "feature"
+      end
+      page_type
+    end
+  end
+end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -16,54 +16,5 @@ module Spotlight
         format.json { render json: current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]) }
       end
     end
-
-    def item_pages
-      item_id = params[:item] || ""
-      pages_json = JSON.parse(current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]))
-      exhibit_id = current_exhibit.id
-      result_array = parse_pages(pages_json, item_id, exhibit_id)
-      # Now get the information
-      render json: { "results" => result_array }.to_json
-    end
-
-    def parse_pages(pages_json, item_id, exhibit_id)
-      result_array = []
-      pages_json.each do |page|
-        page_id = page["id"]
-        title = page["title"]
-        slug = page["slug"]
-        if page["content"].length.positive? && !page["content"].empty?
-          content = page["content"]
-          result_array.concat parse_page_content(content, item_id, page_id, title, slug)
-        end
-      end
-      { "exhibit_id" => exhibit_id, "pages" => result_array }
-    end
-
-    def parse_page_content(content, item_id, page_id, title, slug)
-      result_array = []
-      content.each do |cont|
-        next unless cont.key?("data") && cont["data"].key?("item") && cont["data"]["item"].keys.length
-        item = cont["data"]["item"]
-        item.each do |_, v|
-          if v["id"] == item_id
-            page_type = get_page_type(page_id)
-            result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug, "pagetype" => page_type })
-          end
-        end
-      end
-      result_array
-    end
-
-    def get_page_type(page_id)
-      page_obj = current_exhibit.pages.find(page_id)
-      page_type = "home"
-      if page_obj.about_page?
-        page_type = "about"
-      elsif page_obj.feature_page?
-        page_type = "feature"
-      end
-      page_type
-    end
   end
 end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -46,10 +46,24 @@ module Spotlight
         next unless cont.key?("data") && cont["data"].key?("item") && cont["data"]["item"].keys.length
         item = cont["data"]["item"]
         item.each do |_, v|
-          result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug }) if v["id"] == item_id
+          if v["id"] == item_id
+            page_type = get_page_type(page_id)
+            result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug, "pagetype" => page_type })
+          end
         end
       end
       result_array
+    end
+
+    def get_page_type(page_id)
+      page_obj = current_exhibit.pages.find(page_id)
+      page_type = "home"
+      if page_obj.about_page?
+        page_type = "about"
+      elsif page_obj.feature_page?
+        page_type = "feature"
+      end
+      page_type
     end
   end
 end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -16,5 +16,40 @@ module Spotlight
         format.json { render json: current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]) }
       end
     end
+
+    def item_pages
+      item_id = params[:item] || ""
+      pages_json = JSON.parse(current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]))
+      exhibit_id = current_exhibit.id
+      result_array = parse_pages(pages_json, item_id, exhibit_id)
+      # Now get the information
+      render json: { "results" => result_array }.to_json
+    end
+
+    def parse_pages(pages_json, item_id, exhibit_id)
+      result_array = []
+      pages_json.each do |page|
+        page_id = page["id"]
+        title = page["title"]
+        slug = page["slug"]
+        if page["content"].length.positive? && !page["content"].empty?
+          content = page["content"]
+          result_array.concat parse_page_content(content, item_id, page_id, title, slug)
+        end
+      end
+      { "exhibit_id" => exhibit_id, "pages" => result_array }
+    end
+
+    def parse_page_content(content, item_id, page_id, title, slug)
+      result_array = []
+      content.each do |cont|
+        next unless cont.key?("data") && cont["data"].key?("item") && cont["data"]["item"].keys.length
+        item = cont["data"]["item"]
+        item.each do |_, v|
+          result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug }) if v["id"] == item_id
+        end
+      end
+      result_array
+    end
   end
 end

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -4,8 +4,11 @@
     show: true
   )
 ) %>
-<div id="related-pages">
-<%= document["id"] %>
-<%= document["spotlight_exhibit_slugs_ssim"] %>
+<%
+  doc_id = document['id'] || ''
+  exhibit_slug = (document.has_key?('spotlight_exhibit_slugs_ssim')) && (document['spotlight_exhibit_slugs_ssim'].length > 0) ? document['spotlight_exhibit_slugs_ssim'][0] : ''
+
+%>
+<div id="related-pages" docid="<%= doc_id %>" exhibitslug="<%= exhibit_slug %>" rooturl="<%= root_url %>">
 <%= current_exhibit.to_s %>
 </div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,0 +1,7 @@
+<%= render(
+  Blacklight::DocumentMetadataComponent.new(
+    fields: document_presenter(document).field_presenters,
+    show: true
+  )
+) %>
+<div>Adding Content</div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -4,4 +4,6 @@
     show: true
   )
 ) %>
-<div>Adding Content</div>
+<div id="related-pages">
+<%= document.to_s %>
+</div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -5,5 +5,7 @@
   )
 ) %>
 <div id="related-pages">
-<%= document.to_s %>
+<%= document["id"] %>
+<%= document["spotlight_exhibit_slugs_ssim"] %>
+<%= current_exhibit.to_s %>
 </div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -9,6 +9,4 @@
   exhibit_slug = (document.has_key?('spotlight_exhibit_slugs_ssim')) && (document['spotlight_exhibit_slugs_ssim'].length > 0) ? document['spotlight_exhibit_slugs_ssim'][0] : ''
 
 %>
-<div id="related-pages" docid="<%= doc_id %>" exhibitslug="<%= exhibit_slug %>" rooturl="<%= root_url %>">
-<%= current_exhibit.to_s %>
-</div>
+<div id="related-pages" docid="<%= doc_id %>" exhibitslug="<%= exhibit_slug %>" rooturl="<%= root_url %>"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/:exhibit_id/itempages' => 'spotlight/pages#item_pages'
+
   ### TODO: Portal access is temporarily removed.  See Issue #35.
   # resources :exhibits, only: [] do
   #   resources :portal_resources, only: [:create, :update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/:exhibit_id/itempages' => 'spotlight/pages#item_pages'
+  get '/:exhibit_id/itempages' => 'spotlight/itempages#item_pages'
 
   ### TODO: Portal access is temporarily removed.  See Issue #35.
   # resources :exhibits, only: [] do


### PR DESCRIPTION
- Set up a separate controller to take the current exhibit id and, separately, to take an item id as a parameter, and return which pages that item is included within,  The controller returns json with page id, slug, page type (about, feature, or home) and title for each page where that item occurs.  
- Updated the routes to enable a path to /:exhibit_id/itempages using this controller
- Added JavaScript for getting the item id on the item/show page, making an AJAX request to the Itempages controller, parsing the page information and generating links to be added to the show page
- Copied over the show page from Blacklight and updated to add a block at the bottom that displays the pages where that item occurs, 
