### PR TITLE
Copyright office request plus pages list update

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ $ docker-compose run -e "RAILS_ENV=test" app bundle exec rspec
    ```sh
    bin/rubocop
    ```
+     
 

--- a/app/assets/javascripts/relatedPages.js
+++ b/app/assets/javascripts/relatedPages.js
@@ -1,0 +1,52 @@
+var relatedPages = {
+    onLoad:function() {
+        //Get current exhibit URL and item id and pass to method
+        var relatedPagesDiv = $("#related-pages");
+        var exhibitSlug = relatedPagesDiv.attr("exhibitslug");
+        var rootUrl = relatedPagesDiv.attr("rooturl");
+        var docid = relatedPagesDiv.attr("docid");
+        if(exhibitSlug != "" && docid != "" && rootUrl != "") {
+          relatedPages.requestPages(rootUrl, exhibitSlug, docid);
+        }
+    },
+    requestPages:function(rootUrl, exhibitSlug, docid) {
+      //Do an AJAX request for this exhibit
+      var url = rootUrl + exhibitSlug + "/itempages?item=" + docid;
+      $.ajax({
+        url : url,
+        success: function(data) {
+          console.log(data);
+          if((data != null) && ("results" in data) && ("pages" in data["results"]) && (data["results"]["pages"].length > 0)) {
+            var pages = data["results"]["pages"];
+            var pageTitles = [];
+            $.each(pages, function(i, v) {
+              pageTitles.push(relatedPages.generatePageLink(v, rootUrl, exhibitSlug));
+            });
+            $("#related-pages").html("This item is used on the following pages: " + pageTitles.join(", "));
+          }
+        },
+        error: function(xhr, status, error) {
+          console.log("Error occurred retrieving page list for " + exhibitSlug + " and item " + docid);
+          console.log(xhr.status + ":" + xhr.statusText + ":" + xhr.responseText);
+        }
+      });
+    },
+    generatePageLink(pageObject, rootUrl, exhibitSlug) {
+      var title = pageObject["title"];
+      var pageSlug = pageObject["slug"];
+      var pageType = pageObject["pagetype"];
+      var pageURL = rootUrl + exhibitSlug;
+      if(pageType == "about") {
+        pageURL += "/about/" + pageSlug;
+      } else if(pageType == "feature") {
+        pageURL += "/feature/" + pageSlug;
+      }
+      return "<a href='" + pageURL + "'>" + title + "</a>";
+    }
+};
+
+Blacklight.onLoad(function() {
+    if ( $("#related-pages").length > 0) {
+      relatedPages.onLoad();
+    }
+  });

--- a/app/controllers/spotlight/itempages_controller.rb
+++ b/app/controllers/spotlight/itempages_controller.rb
@@ -1,0 +1,53 @@
+module Spotlight
+  class ItempagesController < Spotlight::ApplicationController
+    # We want this request to be fully open since this information needs to be visible to users viewing the exhibit
+    def item_pages
+      item_id = params[:item] || ""
+      pages_json = JSON.parse(current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]))
+      exhibit_id = current_exhibit.id
+      result_array = parse_pages(pages_json, item_id, exhibit_id)
+      # Now get the information
+      render json: { "results" => result_array }.to_json
+    end
+
+    def parse_pages(pages_json, item_id, exhibit_id)
+      result_array = []
+      pages_json.each do |page|
+        page_id = page["id"]
+        title = page["title"]
+        slug = page["slug"]
+        if page["content"].length.positive? && !page["content"].empty?
+          content = page["content"]
+          result_array.concat parse_page_content(content, item_id, page_id, title, slug)
+        end
+      end
+      { "exhibit_id" => exhibit_id, "pages" => result_array }
+    end
+
+    def parse_page_content(content, item_id, page_id, title, slug)
+      result_array = []
+      content.each do |cont|
+        next unless cont.key?("data") && cont["data"].key?("item") && cont["data"]["item"].keys.length
+        item = cont["data"]["item"]
+        item.each do |_, v|
+          if v["id"] == item_id
+            page_type = get_page_type(page_id)
+            result_array.push({ "pageid" => page_id, "title" => title, "slug" => slug, "pagetype" => page_type })
+          end
+        end
+      end
+      result_array
+    end
+
+    def get_page_type(page_id)
+      page_obj = current_exhibit.pages.find(page_id)
+      page_type = "home"
+      if page_obj.about_page?
+        page_type = "about"
+      elsif page_obj.feature_page?
+        page_type = "feature"
+      end
+      page_type
+    end
+  end
+end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -1,0 +1,20 @@
+# Override pattern seen in https://github.com/sul-dlss/exhibits/blob/master/app/controllers/spotlight/home_pages_controller.rb
+spotlight_path = Gem::Specification.find_by_name('blacklight-spotlight').full_gem_path
+require_dependency File.join(spotlight_path, 'app/controllers/spotlight/pages_controller')
+
+module Spotlight
+  # Override the upstream PagesController in order to override the pages.json implementation
+  class PagesController
+    # GET /exhibits/1/pageslist
+    def index
+      @page = CanCan::ControllerResource.new(self).send(:build_resource)
+
+      # Using current_exhibit instead of @pages shows the full list of pages for the exhibit, including unpublished ones,
+      # and not just for the superadmin role, so for regular admins and curators
+      respond_to do |format|
+        format.html
+        format.json { render json: current_exhibit.pages.for_default_locale.published.to_json(methods: [:thumbnail_image_url]) }
+      end
+    end
+  end
+end

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,0 +1,12 @@
+<%= render(
+  Blacklight::DocumentMetadataComponent.new(
+    fields: document_presenter(document).field_presenters,
+    show: true
+  )
+) %>
+<%
+  doc_id = document['id'] || ''
+  exhibit_slug = (document.has_key?('spotlight_exhibit_slugs_ssim')) && (document['spotlight_exhibit_slugs_ssim'].length > 0) ? document['spotlight_exhibit_slugs_ssim'][0] : ''
+
+%>
+<div id="related-pages" docid="<%= doc_id %>" exhibitslug="<%= exhibit_slug %>" rooturl="<%= root_url %>"></div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
     <div class="col-sm-10">
-      <p>©2021 Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
+      <p><a href="https://www.library.cornell.edu/copyright">©<%= Time.zone.now.year %></a> Cornell University Library, Ithaca, NY 14853 | (607) 255-4144 | <a href="http://www.library.cornell.edu/privacy">Privacy</a> | <a href="https://www.library.cornell.edu/web-accessibility">Web Accessibility Assistance</a></p>
       <% if current_user %>
       <p><small><a href="https://cul-it.github.io/exhibits-library-cornell-edu/"><%= t(:'local_documentation') %></a></small></p>
       <% end %>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -38,6 +38,27 @@ Spotlight::Engine.config.resource_partials = [
 # Spotlight::Engine.config.full_image_field = :full_image_url_ssm
 # Spotlight::Engine.config.thumbnail_field = :thumbnail_url_ssm
 
+# ==> Adding copyright to default configuration.  Note "UploadFieldConfig" needs to be preceded by "Spotlight::".  
+# Refer to https://github.com/projectblacklight/spotlight/blob/v3.3.0/lib/spotlight/engine.rb
+Spotlight::Engine.config.upload_fields = [
+  Spotlight::UploadFieldConfig.new(
+     field_name: Spotlight::Engine.config.upload_description_field,
+     label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.upload_description_field}") },
+     form_field_type: :text_area
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_upload_attribution_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_upload_date_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
+   ),
+   Spotlight::UploadFieldConfig.new(
+     field_name: :spotlight_copyright_tesim,
+     label: -> { I18n.t(:'spotlight.search.fields.spotlight_copyright_tesim') }
+   )
+ ]
 # ==> Uploaded item configuration
 # Spotlight::Engine.config.upload_fields = [
 #   UploadFieldConfig.new(

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -38,7 +38,7 @@ Spotlight::Engine.config.resource_partials = [
 # Spotlight::Engine.config.full_image_field = :full_image_url_ssm
 # Spotlight::Engine.config.thumbnail_field = :thumbnail_url_ssm
 
-# ==> Adding copyright to default configuration.  Note "UploadFieldConfig" needs to be preceded by "Spotlight::".  
+# ==> Adding copyright to default configuration.  Note "UploadFieldConfig" needs to be preceded by "Spotlight::".
 # Refer to https://github.com/projectblacklight/spotlight/blob/v3.3.0/lib/spotlight/engine.rb
 Spotlight::Engine.config.upload_fields = [
   Spotlight::UploadFieldConfig.new(
@@ -46,19 +46,19 @@ Spotlight::Engine.config.upload_fields = [
      label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.upload_description_field}") },
      form_field_type: :text_area
    ),
-   Spotlight::UploadFieldConfig.new(
+  Spotlight::UploadFieldConfig.new(
      field_name: :spotlight_upload_attribution_tesim,
      label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_attribution_tesim') }
    ),
-   Spotlight::UploadFieldConfig.new(
+  Spotlight::UploadFieldConfig.new(
      field_name: :spotlight_upload_date_tesim,
      label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
    ),
-   Spotlight::UploadFieldConfig.new(
+  Spotlight::UploadFieldConfig.new(
      field_name: :spotlight_copyright_tesim,
      label: -> { I18n.t(:'spotlight.search.fields.spotlight_copyright_tesim') }
    )
- ]
+]
 # ==> Uploaded item configuration
 # Spotlight::Engine.config.upload_fields = [
 #   UploadFieldConfig.new(

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -13,6 +13,9 @@ en:
         destroy: Remove from exhibit creator role
         instructions: Existing exhibit creators
         update: Make user an exhibit creator
+    search:
+      fields:
+        spotlight_copyright_tesim: Copyright
   shared:
     site_sidebar:
       documentation: Spotlight curator documentation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/:exhibit_id/itempages' => 'spotlight/itempages#item_pages'
+
   ### TODO: Portal access is temporarily removed.  See Issue #35.
   # resources :exhibits, only: [] do
   #   resources :portal_resources, only: [:create, :update] do

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Version
-  VERSION = "v3.0.0".freeze
+  VERSION = "v3.1.0".freeze
 end


### PR DESCRIPTION
Covers:

- updating pages controller to return json of all pages (which is used by SirTrevor pages widget) even if not logged in as superadmin (e.g. as regular exhibit admin/curator)
- copyright field in form and display: Copyright field added to field configuration. Available for any exhibit on the site. 
- where item is used in exhibit pages: relying on pages..sjon
- copyright link in footer: Add link to https://www.library.cornell.edu/copyright and make year the current year (do not leave as 2021)
- version: bump to 3.1.0