### PR TITLE
Expose env variables in elastic beanstalk instance shells

### DIFF
--- a/.ebextensions/setvars.config
+++ b/.ebextensions/setvars.config
@@ -1,0 +1,6 @@
+commands:
+    setvars:
+        command: /opt/elasticbeanstalk/bin/get-config environment | jq -r 'to_entries | .[] | "export \(.key)=\"\(.value)\""' > /etc/profile.d/sh.local
+packages:
+    yum:
+        jq: []


### PR DESCRIPTION
Env variables aren't available to user when ssh-ing into elastic beanstalk instances. So it's not possible to access the rails console on the eb-managed aws servers, for example.

Followed a tip from [stackoverflow](https://stackoverflow.com/questions/19620897/can-you-run-a-rails-console-or-rake-command-in-the-elastic-beanstalk-environment), this PR adds an .ebextension file that exports the environment variables to operating system variables. Uses this recipe from the eb docs:
https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-env-variables-shell/

Deployed to our integration server and confirmed I can now open a rails console.