### PR TITLE
Change hover text for item zoom buttons

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,9 @@
 en:
   blacklight:
     application_name: 'Online Exhibitions'
+    icon:
+      add_circle: Zoom In
+      remove_circle: Zoom Out
   views:
     pagination:
       first: 'First'


### PR DESCRIPTION
Quick fix for https://github.com/cul-it/exhibits-library-cornell-edu/issues/508

Changes hover text for item zoom buttons to "Zoom In" and "Zoom Out" (instead of "Add Circle" and "Remove Circle").