### PR TITLE
Use puma gem version instead of puma default on eb

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C /opt/elasticbeanstalk/config/private/pumaconf.rb


### PR DESCRIPTION
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ruby-platform-procfile.html

Use puma version specified by Gemfile, instead of default puma installed with elastic beanstalk.