### PR TITLE
Fix missing abilities for Browse pages and Viewers

### DIFF
--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -31,6 +31,7 @@ module Spotlight
         can :manage, [
           Spotlight::Attachment,
           Spotlight::Search,
+          Spotlight::Group,
           Spotlight::Resource,
           Spotlight::Page,
           Spotlight::Contact,

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -51,6 +51,8 @@ module Spotlight
       can :read, Spotlight::Search, published: true
       can :read, Spotlight::Group, published: true
       can :read, Spotlight::Language, public: true
+
+      can :read, Spotlight::Exhibit, id: user.viewer_roles.pluck(:resource_id)
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -49,6 +49,7 @@ module Spotlight
       can :read, Spotlight::Exhibit, published: true
       can :read, Spotlight::Page, published: true
       can :read, Spotlight::Search, published: true
+      can :read, Spotlight::Group, published: true
       can :read, Spotlight::Language, public: true
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity


### PR DESCRIPTION
- https://culibrary.atlassian.net/browse/LP-706: Add published Browse groups to public pages
    - Also gave curators ability to update browse groups, which appeared to be missing when comparing our Spotlight::Ability to https://github.com/projectblacklight/spotlight/blob/v3.5.0.2/app/models/spotlight/ability.rb
- https://culibrary.atlassian.net/browse/LP-707: Allow users with Viewer role to view unpublished exhibits

Not sure why these were missing - maybe they were missed during a previous Spotlight upgrade?