### PR TITLE
LP-571 Add border to Text field in widgets and adjust font size

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -52,6 +52,15 @@ p, li {
 	border-left: 5px solid #eee;
 }
 
+// #571 - border to text form fields
+.st-block [contenteditable="true"]
+{
+	border: 1px solid #d4d4d4;
+	p {
+    	font-size: 1rem;
+	}
+}
+
 // #433 - color contrast is insufficient for all of the following:
 .page-item.active .page-link {
 	border-color: $almost-black;

--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -52,7 +52,7 @@ p, li {
 	border-left: 5px solid #eee;
 }
 
-// #571 - border to text form fields
+// #571 - border to text form fields, and font size adjustment
 .st-block [contenteditable="true"]
 {
 	border: 1px solid #d4d4d4;


### PR DESCRIPTION
I also noticed the font size was larger than the other form elements, so that has been adjusted. 
This is what it looks like with the new changes:

![image](https://github.com/cul-it/exhibits-library-cornell-edu/assets/144364984/cb224905-dad0-4c57-8fe3-56a71311fd44)
