### PR TITLE
LP-482 - Set up devise routes before spotlight engine routes

### DIFF
--- a/.env.circleci
+++ b/.env.circleci
@@ -19,3 +19,5 @@ REDIS_URL=http://redis:6379/0
 
 # Valid values for ACCESS are NORMAL | SITE_ADMIN_ONLY
 ACCESS_MODE=NORMAL
+
+SELENIUM_DRIVER_URL=http://chrome:4444/wd/hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM ruby:$RUBY_VERSION-alpine
 ## - tzdata: add time zone support
 ## - mariadb-dev: To allow use of MySQL gem
 ## - imagemagick: for image processing
+## - chromium-chromedriver: for js-enabled tests
 RUN apk add --update --no-cache \
       bash \
       build-base \
@@ -17,7 +18,8 @@ RUN apk add --update --no-cache \
       sqlite-dev \
       tzdata \
       mariadb-dev \
-      imagemagick
+      imagemagick \
+      chromium-chromedriver
 
 
 WORKDIR /app/cul-it/exhibits-webapp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
   mount OkComputer::Engine, at: "/syscheck"
 
+  devise_for :users
+
   mount Spotlight::Engine, at: '/' # as opposed to `at: 'spotlight'` which was generated
   mount Blacklight::Engine => '/'
   # root to: "catalog#index" # replaced by spotlight root path
@@ -16,7 +18,6 @@ Rails.application.routes.draw do
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
   end
-  devise_for :users
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - mysql
       - redis
       - solr
+      - chrome
 
   mysql:
     image: mariadb
@@ -71,6 +72,11 @@ services:
     command:
       - redis-server
 
+  chrome:
+    image: seleniarm/standalone-chromium
+    ports:
+      - 4444:4444
+
 volumes:
   app_src: # comment out when debugging and using . volume for exhibits-webapp
   db-mysql-data:
@@ -79,3 +85,4 @@ volumes:
   rails-tmp:
   redis:
   solr_home:
+  chrome:

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -1,23 +1,41 @@
 require 'rails_helper'
 
-RSpec.feature "Unauthorized Access", type: :feature do
-  scenario "Go to home page without logging in first" do
-    visit "/users/sign_in"
+RSpec.feature 'Unauthorized Access', type: :feature do
+  scenario 'Go to home page without logging in first' do
+    visit '/users/sign_in'
 
-    expect(page).to have_text("Forgot your password?")
+    expect(page).to have_text('Forgot your password?')
   end
 end
 
-RSpec.feature "Authorized Access", type: :feature do
-  scenario "Log in and reach home page" do
-    user = FactoryBot.create(:user)
+RSpec.feature 'Authorized Access', type: :feature do
+  let(:user) { create(:user) }
 
-    visit "/users/sign_in"
+  scenario 'Log in and reach home page' do
+    visit '/users/sign_in'
 
     fill_in('user_email', with: user.email)
     fill_in('user_password', with: user.password)
     click_button('Log in')
 
     expect(page).to have_text('Signed in successfully.')
+  end
+
+  scenario 'Log in and reset password', js: true do
+    login_as(user)
+    visit '/'
+
+    click_link(user.email)
+    click_link('Change Password')
+
+    expect(page).to have_text('Edit User')
+
+    fill_in('user_email', with: user.email)
+    fill_in('user_password', with: '123456!')
+    fill_in('user_password_confirmation', with: '123456!')
+    fill_in('user_current_password', with: user.password)
+    click_button('Update')
+
+    expect(page).to have_text('Your account has been updated successfully.')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,5 +67,23 @@ RSpec.configure do |config|
     Warden.test_reset!
   end
 
-  Capybara.javascript_driver = :selenium_chrome_headless
+  if ENV['SELENIUM_DRIVER_URL'].present?
+    Capybara.server_host =
+      begin
+        IPSocket.getaddress(Socket.gethostname)
+      rescue SocketError
+        'webapp'
+      end
+    Capybara.server_port = 4000
+
+    Capybara.register_driver :chrome_remote do |app|
+      Capybara::Selenium::Driver.new app,
+        browser: :remote,
+        url: ENV['SELENIUM_DRIVER_URL'],
+        options: Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu])
+    end
+    Capybara.javascript_driver = :chrome_remote
+  else
+    Capybara.javascript_driver = :selenium_chrome_headless
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Set up Devise and Warden helpers for login
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Warden::Test::Helpers
+
+  config.before(:each, type: :feature) do
+    Warden.test_mode!
+  end
+
+  config.after(:each, type: :feature) do
+    Warden.test_reset!
+  end
+
+  Capybara.javascript_driver = :selenium_chrome_headless
 end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-482

- Moves devise routes up before the spotlight engine routes so that /users/edit can be recognized as a devise route instead of an exhibit edit path
- Adds new js feature spec w/ capybara js driver
- Sets up chrome docker image for js testing on circleci