### PR TITLE
LP-478 - Sort recently published exhibits at beginning of index by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
+  gem 'timecop'
   gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,6 +615,7 @@ GEM
       nokogiri (>= 1.3.2)
     thor (1.3.0)
     tilt (2.3.0)
+    timecop (0.9.8)
     timeout (0.4.1)
     tins (1.32.1)
       sync
@@ -719,6 +720,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen
   sqlite3
+  timecop
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data

--- a/app/models/concerns/cul/exhibit_defaults.rb
+++ b/app/models/concerns/cul/exhibit_defaults.rb
@@ -6,11 +6,17 @@ module Cul
     extend ActiveSupport::Concern
 
     included do
-      before_save :set_published_at
+      before_save :set_published
     end
 
-    def set_published_at
-      self.published_at = Time.zone.now if published? && published_changed?
+    def set_published
+      return unless published? && published_changed?
+
+      # Don't reset weight if previously published
+      self.weight = 0 unless published_at
+
+      # Set published_at date
+      self.published_at = Time.zone.now
     end
   end
 end

--- a/app/prepends/prepended_controllers/exhibits_controller.rb
+++ b/app/prepends/prepended_controllers/exhibits_controller.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 # Based on the Module#prepend pattern in ruby.
-# Uses the to_prepare Rails hook in application.rb to inject this module to override Spotlight::ReindexJob module
+# Uses the to_prepare Rails hook in application.rb to inject this module to override Spotlight::Exhibit
 module PrependedControllers::ExhibitsController
+  # Overrides published exhibit order in so that exhibits are ordered first by asc weight, then by most recently published
+  def index
+    @published_exhibits = @exhibits.includes(:thumbnail).published.order(weight: :asc, published_at: :desc).page(params[:page])
+    @published_exhibits = @published_exhibits.tagged_with(params[:tag]) if params[:tag]
+    if @exhibits.one?
+      redirect_to @exhibits.first, flash: flash.to_h
+    else
+      render layout: 'spotlight/home'
+    end
+  end
+
   protected
 
   # override exhibit_params method to convert tag_list params from array to comma separated list

--- a/spec/controllers/exhibits_controller_spec.rb
+++ b/spec/controllers/exhibits_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Spotlight::ExhibitsController, type: :controller do
+  describe 'GET index' do
+    context 'multiple published exhibits' do
+      it 'orders published exhibits by asc weight first, then desc published_dat dates' do
+        # Set up exhibits
+        published_exhibit1 = create(:exhibit, published: true).tap { |e| e.update(weight: 10, published_at: nil) }
+        published_exhibit2 = create(:exhibit, published: true).tap { |e| e.update(weight: 0) }
+        create(:exhibit, published: false, weight: 0)
+        published_exhibit3 = create(:exhibit, published: true).tap { |e| e.update(weight: 20) }
+        published_exhibit4 = create(:exhibit, published: true).tap { |e| e.update(weight: 10, published_at: 1.day.ago) }
+        published_exhibit5 = create(:exhibit, published: true).tap { |e| e.update(weight: 10) }
+
+        # Check published_exhibits order on index
+        get :index
+        expect(response).to render_template('spotlight/home')
+        expect(assigns(:published_exhibits)).to eq([published_exhibit2, published_exhibit5, published_exhibit4, published_exhibit1, published_exhibit3])
+      end
+    end
+
+    context 'one exhibit' do
+      it 'redirects to the exhibit' do
+        exhibit = create(:exhibit, published: true)
+        get :index
+        expect(response).to redirect_to(exhibit)
+      end
+    end
+  end
+end

--- a/spec/factories/exhibits.rb
+++ b/spec/factories/exhibits.rb
@@ -2,6 +2,5 @@
 FactoryBot.define do
   factory :exhibit, class: 'Spotlight::Exhibit' do
     title { 'My Exhibit' }
-    slug { 'my-exhibit' }
   end
 end

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe Spotlight::Exhibit, type: :model do
+  describe 'callbacks' do
+    describe '#set_published' do
+      context 'publishing an exhibit' do
+        let(:exhibit) { create(:exhibit, published: false, published_at: nil) }
+
+        it 'sets published_at date and resets weight' do
+          expect(exhibit.weight).to eq(50)
+
+          # Publish exhibit
+          new_published_at = Time.zone.now
+          Timecop.freeze(new_published_at) do
+            exhibit.published = true
+            exhibit.save!
+          end
+          expect(exhibit.published_at).to eq(new_published_at)
+          expect(exhibit.weight).to eq(0)
+        end
+      end
+
+      context 'publishing an exhibit that has previously been published' do
+        let(:exhibit) { create(:exhibit, published: false, published_at: Time.zone.now - 1.day, weight: 10) }
+
+        it 'resets published_at only, not weight' do
+          # Publish exhibit
+          new_published_at = Time.zone.now
+          Timecop.freeze(new_published_at) do
+            exhibit.published = true
+            exhibit.save!
+          end
+          expect(exhibit.published_at).to eq(new_published_at)
+          expect(exhibit.weight).to eq(10)
+        end
+      end
+
+      context 'saving already published exhibit' do
+        let!(:exhibit) { create(:exhibit, published: true) }
+        let(:published_at) { exhibit.published_at }
+
+        it 'does not reset published_at or weight' do
+          # Save exhibit
+          exhibit.weight = 10
+          exhibit.save!
+          expect(exhibit.published_at).to eq(published_at)
+          expect(exhibit.weight).to eq(10)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-478

- Resets weight to 0 for exhibits that are newly published (does not change weight if exhibit was previously published, returned to draft, then published again, to prevent any strange gaming of the system)
   - Exhibits are secondarily sorted by published_at dates after weight
- Does not change order in "Unpublished exhibits" or "Your exhibits" lists (default weight is set to 50 in database).
- Order can be reset still in "Order exhibits" superadmin dashboard, e.g. https://exhibits-int.library.cornell.edu/exhibits/edit