### PR TITLE
LP-1036 - Cron job to clear tmp/network_files

### DIFF
--- a/.platform/hooks/postdeploy/52_setup_cron.sh
+++ b/.platform/hooks/postdeploy/52_setup_cron.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Writes cron jobs to crontab defined in rails app via whenever gem
+
+EB_APP_DEPLOY_DIR=$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppDeployDir)
+cd $EB_APP_DEPLOY_DIR
+
+set -xe
+export $(cat /opt/elasticbeanstalk/deployment/env | xargs)
+
+echo "Setting up cron jobs via rails app"
+su -s /bin/bash -c "bundle exec whenever --update-crontab"

--- a/.platform/hooks/postdeploy/52_setup_cron.sh
+++ b/.platform/hooks/postdeploy/52_setup_cron.sh
@@ -3,10 +3,13 @@
 # Writes cron jobs to crontab defined in rails app via whenever gem
 
 EB_APP_DEPLOY_DIR=$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppDeployDir)
+EB_APP_USER=$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppUser)
+RACK_ENV=$(/opt/elasticbeanstalk/bin/get-config environment -k RACK_ENV)
+
 cd $EB_APP_DEPLOY_DIR
 
 set -xe
 export $(cat /opt/elasticbeanstalk/deployment/env | xargs)
 
 echo "Setting up cron jobs via rails app"
-su -s /bin/bash -c "bundle exec whenever --update-crontab"
+su -s /bin/bash -c "bundle exec whenever --update-crontab --user $EB_APP_USER --set 'environment=$RACK_ENV'"

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 4.2.0'
+gem 'whenever', require: false
 
 # Gems manually added to control blacklight and spotlight versions
 gem 'blacklight', '~> 7.36.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
     carrierwave-aws (1.6.0)
       aws-sdk-s3 (~> 1.0)
       carrierwave (>= 2.0, < 4)
+    chronic (0.10.2)
     clipboard-rails (1.7.1)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -660,6 +661,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.13)
@@ -728,6 +731,7 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
+  whenever
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-* [Ruby 3.0.5](https://www.ruby-lang.org/en/documentation/installation/)
+* [Ruby 3.2.2](https://www.ruby-lang.org/en/documentation/installation/)
 * [Bundler 2](https://bundler.io/)
 * [ImageMagick](https://imagemagick.org/script/download.php)
 * [Solr](https://solr.apache.org/guide/solr/latest/deployment-guide/installing-solr.html)

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -19,5 +19,5 @@ ActiveSupport::Reloader.to_prepare do
 
   # Riiif.not_found_image = 'app/assets/images/us_404.svg'
   #
-  Riiif::Engine.config.cache_duration = 365.days
+  Riiif::Engine.config.cache_duration = 30.days
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :day, at: '2:05am' do
+  rake 'riiif:clear_cache'
+end

--- a/lib/tasks/riiif.rake
+++ b/lib/tasks/riiif.rake
@@ -1,0 +1,20 @@
+namespace :riiif do
+  desc 'Clear the riiif cache if it exceeds 50GB'
+  task clear_cache: :environment do
+    # Get the size of the tmp/network_files directory
+    size = `du -sh tmp/network_files`.split("\t").first
+
+    # If the size is over 50GB, delete the oldest files until under 50GB
+    deleted_file_count = 0
+    while !size.nil? && size.match(/^(\d+(?:\.\d+)?)G$/) && Regexp.last_match(1).to_f > 50
+      # Get the oldest file in the tmp/network_files directory
+      oldest_file = `ls -t tmp/network_files | tail -n 1`.chomp
+      # Delete the oldest file
+      `rm tmp/network_files/#{oldest_file}`
+      deleted_file_count += 1
+      # Get the new size of the tmp/network_files directory
+      size = `du -sh tmp/network_files`.split("\t").first
+    end
+    Rails.logger.info("Completed riiif:clear_cache rake task. Cleared #{deleted_file_count} files from tmp/network_files.")
+  end
+end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-1036

- Adds daily cron job to clear tmp/network_files if disk usage exceeds 50G. Clears out oldest files one by one until disk usage is back under 50G.
   - Adds cron job via whenever gem, updates crontab with elastic beanstalk post deploy hook
        - Do I also need to set this up as postdeploy confighook? This won't matter soon once we get off EB.
- Also updates riiif cache_duration config to max 30 days, but not completely certain this does anything. Previous cache_duration of 365.days seemed like too much though.
- README fix