### PR TITLE
LP-833, LP-649 - Support tiff item uploads, tweak styling on item show

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -72,8 +72,7 @@ p, li {
 .navbar-dark .navbar-nav .nav-link, .image-masthead .exhibit-navbar .navbar-nav .nav-link, .masthead .exhibit-navbar .navbar-nav .nav-link {
 	color: white;
 }
-.breadcrumb-item.active,
-.dl-invert dt {
+.breadcrumb-item.active {
 	color: inherit;
 }
 

--- a/app/helpers/spotlight_helper.rb
+++ b/app/helpers/spotlight_helper.rb
@@ -3,6 +3,7 @@
 ##
 # Global Spotlight helpers
 module SpotlightHelper
+  include Blacklight::OpenseadragonHelper
   include ::BlacklightHelper
   include Spotlight::MainAppHelpers
 
@@ -19,5 +20,10 @@ module SpotlightHelper
       ERB::Util.html_escape(value).gsub(/\[([^\[]+)\]\(([^\)]+)\)/, '<a href="\2">\1</a>')
     end.join
     sanitize(safe_html)
+  end
+
+  # Overrides osd_container_class of "col-md-6" from blacklight-gallery
+  def osd_container_class
+    ''
   end
 end

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -77,7 +77,7 @@ Spotlight::Engine.config.upload_fields = [
 # ]
 # Spotlight::Engine.config.upload_title_field = nil # UploadFieldConfig.new(...)
 Spotlight::Engine.config.uploader_storage = :aws if ENV['S3_KEY_ID'].present?
-# Spotlight::Engine.config.allowed_upload_extensions = %w(jpg jpeg png)
+Spotlight::Engine.config.allowed_upload_extensions = %w(jpg jpeg png tiff tif)
 
 # Spotlight::Engine.config.featured_image_thumb_size = [400, 300]
 # Spotlight::Engine.config.featured_image_square_size = [400, 400]


### PR DESCRIPTION
- https://culibrary.atlassian.net/browse/LP-833 - Allows curators to upload tiffs as exhibit items
- https://culibrary.atlassian.net/browse/LP-649 - Minor styling changes to make OSD viewer full width and removes color override for metadata dt
   - The text that displays "This item is used on the following pages..." still pops up via JS under the metadata and could probably be restyled, but thought we could revisit that along with whether this should be rendered via js or server-side via rails at another time (unless you have immediate suggestions!!).
   - Any other styling suggestions? The Stanford exhibit item link (https://exhibits.stanford.edu/martin-wong/catalog/px657rx0792) that was shared by our CUL Exhibits committee looks basically the same now (except for their iiif viewer, which is completely different). If we ever have exhibits that contain items with lots of metadata, we could consider adding in a More Details button as well.
   - Example on exhibits-int: https://exhibits-int.library.cornell.edu/once-more-with-feeling/catalog/100-5430

This code has been deployed to exhibits-int.