### PR TITLE
LP-1087 - Clean up guest users via cron

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-guests (0.8.2)
+    devise-guests (0.8.3)
       devise
     devise_invitable (2.0.9)
       actionmailer (>= 5.0)
@@ -307,7 +307,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     i18n-active_record (1.3.0)
       i18n (>= 0.5.0)
@@ -628,7 +628,7 @@ GEM
     test_xml (0.1.8)
       diffy (~> 3.0)
       nokogiri (>= 1.3.2)
-    thor (1.3.1)
+    thor (1.3.2)
     tilt (2.4.0)
     timecop (0.9.8)
     timeout (0.4.1)
@@ -679,7 +679,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   aarch64-linux

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,17 +19,22 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Clean up anonymous search records > 7 days
-every :day, at: '1:00am' do
-  rake 'blacklight:delete_old_searches[7]'
-end
-
 # Clean up tmp/network_files > 50GB
-every :day, at: '2:05am' do
+every :day, at: '1:00am' do
   rake 'spotlight:riiif:clear_cache'
 end
 
+# Clean up anonymous search records > 7 days
+every :wednesday, at: '2:00am' do
+  rake 'blacklight:delete_old_searches[7]'
+end
+
 # Clean up PaperTrail versions > 365 days
-every :day, at: '3:00am' do
+every :wednesday, at: '3:00am' do
   rake 'spotlight:paper_trail:clear[365]'
+end
+
+# Clean up guest users > 2 days
+every :wednesday, at: '4:00am' do
+  rake 'devise_guests:delete_old_guest_users[2]'
 end


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-1087

- Sets up guest user cleanup cron job
- Changes db cleanup tasks to weekly instead of daily, since not needed that often
- Updates devise-guests gem to fix delete_old_guest_users bug in prev version

Should be the final thing needed to close out https://github.com/cul-it/exhibits-library-cornell-edu/issues/409