### PR TITLE
Actually persist db data in dev container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Web server: http://localhost:9292
 
 Solr: http://localhost:8983
 
+Sidekiq: http://localhost:9292/sidekiq
+
+#### Set up initial data
+
+1. Set up admin user using the SITE_ADMINS email set in your dotenv file: `bundle exec rake spotlight:initialize`
+
+1. Set up initial exhibit: `bundle exec rake spotlight:exhibit`
+
 #### Testing in Docker
 
 Run full test suite:

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,7 +34,7 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - db-data:/var/lib/mysql/data
+      - db-data:/var/lib/mysql
 
   solr:
     extends:


### PR DESCRIPTION
Whoops, mysql data was not properly getting persisted across container builds/stops/starts in dev environment. Now it should!

Also updated README a bit with data setup instructions, to match manual setup instructions.