### PR TITLE
LP-1092 - Help text and styling tweaks

### DIFF
--- a/app/assets/stylesheets/exhibits/_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_blocks.scss
@@ -4,6 +4,10 @@
 	padding: 5px 0;
 }
 
+.browse-category {
+  overflow: hidden;
+}
+
 // Tile sizing
 // Override Spotlight to enable multiple rows if tiles >5
 // Fixes: https://github.com/cul-it/exhibits-library-cornell-edu/issues/448
@@ -30,8 +34,8 @@
       }
 
       @media (min-width: breakpoint-min("lg")) {
-        width: $lg-five-tile-width;
-        height: $lg-five-tile-width * $aspect-ratio-factor-4x3;
+        width: $lg-three-tile-width;
+        height: $lg-three-tile-width * $aspect-ratio-factor-4x3;
       }
 
       @media (min-width: breakpoint-min("xl")) {

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -1,4 +1,8 @@
 en:
+  activerecord:
+    help:
+      spotlight/exhibit:
+        tag_list: Cmd+click or Ctrl+click to select multiple tags.
   spotlight:
     confirmation_mailer:
       confirmation_instructions:


### PR DESCRIPTION
- Updates help text for exhibit tag list
- [LP-1092: Fix large device breakpoint styling for page widget](https://culibrary.atlassian.net/browse/LP-1092)
   - Tweaks styling for page and browse category widgets so that "large" devices (992-1200px) show a max of 3 per row
   - Doesn't allow category-title to overflow container (instead just cuts off at top...)
   - We may just have to encourage curators not to have pages with long titles if they want to include in the page widget. The examples I saw in Stanford's page widgets have much shorter titles, e.g. https://exhibits.stanford.edu/arizonagarden and https://exhibits.stanford.edu/parker

Previously:
<img width="953" alt="Screenshot 2024-09-18 at 4 21 44 PM" src="https://github.com/user-attachments/assets/22facc25-fd23-479f-ab35-e845246103dd">

Now:
<img width="960" alt="Screenshot 2024-09-18 at 4 20 48 PM" src="https://github.com/user-attachments/assets/d2d677a2-b7c7-4f35-878f-27b637db2358">