### PR TITLE
Set correct environment when starting sidekiq on containers

### DIFF
--- a/docker/puma.sh
+++ b/docker/puma.sh
@@ -23,7 +23,7 @@ sh ./docker/db_prepare.sh
 exec "$@"
 
 # Start sidekiq
-bundle exec sidekiq -d -L log/sidekiq.log -e development
+bundle exec sidekiq -d -L log/sidekiq.log -e $RAILS_ENV
 
 # Start the web server
 mkdir -p ./tmp/pids

--- a/docker/puma.sh
+++ b/docker/puma.sh
@@ -23,8 +23,8 @@ sh ./docker/db_prepare.sh
 exec "$@"
 
 # Start sidekiq
-bundle exec sidekiq -d -L log/sidekiq.log -e $RAILS_ENV
+bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
 
 # Start the web server
 mkdir -p ./tmp/pids
-bundle exec puma -C config/puma.rb
+bundle exec puma -C config/puma.rb -e $RAILS_ENV


### PR DESCRIPTION
Sidekiq didn't seem to be running on exhibits-container with `ps aux | grep [s]idekiq`, so I tried to mimic the way sidekiq is getting started in the elastic beanstalk configs (minus pids). Seems to be running now after I deployed this branch to exhibits-container, and sidekiq jobs are finishing.