### PR TITLE
Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,7 @@ FROM dev_base as test
 ENV RAILS_ENV=test \
     APP_PATH=/exhibits
 
-# Install application gems
 WORKDIR $APP_PATH
-COPY Gemfile Gemfile.lock ./
-RUN bundle install
-
 COPY . .
 
 ENTRYPOINT [ "docker/build_test.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --chown=${USER}:${GROUP} . .
 
 # Run the web server
 EXPOSE 9292
-ENTRYPOINT [ "docker/puma.sh" ]
+ENTRYPOINT [ "docker/run_dev.sh" ]
 
 ################################################################################
 # Bundle production/integration/staging environment
@@ -122,4 +122,4 @@ WORKDIR ${APP_PATH}
 
 # Run the web server
 EXPOSE 9292
-ENTRYPOINT [ "docker/puma.sh" ]
+ENTRYPOINT [ "docker/run.sh" ]

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ gem 'blacklight-spotlight', '~> 3.5'
 group :development do
   gem 'better_errors' # add command line in browser when errors
   gem 'binding_of_caller' # deeper stack trace used by better errors
-  gem 'letter_opener' # show emails in browser
   gem 'listen'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,8 +356,6 @@ GEM
       railties (>= 4.2.0)
     legato (0.7.0)
       multi_json
-    letter_opener (1.8.1)
-      launchy (>= 2.2, < 3)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -713,7 +711,6 @@ DEPENDENCIES
   irb
   jbuilder (~> 2.5)
   jquery-rails
-  letter_opener
   listen
   mina
   mysql2

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Configure Email Notifications
-  config.action_mailer.delivery_method = :letter_opener # Open emails in a web browser
+  config.action_mailer.delivery_method = :test
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+# Install gems
+bundle install
+
 # Prepare DB (Migrate if exists; else Create db & Migrate)
 sh ./docker/db_prepare.sh
 
-# Run the command defined in compose.test.yaml
+# Run commands
 exec "$@"

--- a/docker/build_test.sh
+++ b/docker/build_test.sh
@@ -5,8 +5,10 @@ set -e
 # Install gems
 bundle install
 
-# Prepare DB (Migrate if exists; else Create db & Migrate)
-sh ./docker/db_prepare.sh
+# If the database exists, migrate. Otherwise setup (create and migrate)
+echo "Preparing Database..."
+bundle exec rake db:environment:set RAILS_ENV=test db:migrate 2>/dev/null || bundle exec rake db:environment:set RAILS_ENV=test db:create db:schema:load
+echo "Database Migration Done!"
 
 # Run commands
 exec "$@"

--- a/docker/db_prepare.sh
+++ b/docker/db_prepare.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# If the database exists, migrate. Otherwise setup (create and migrate)
-echo "Preparing Database..."
-bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:environment:set RAILS_ENV=$RAILS_ENV db:create db:schema:load
-echo "Database Migration Done!"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -16,11 +16,10 @@ then
   cron
 fi
 
-# Prepare DB (Migrate if exists; else Create db & Migrate)
-sh ./docker/db_prepare.sh
-
-# Run the command defined in compose.yaml
-exec "$@"
+# Run db migrations
+echo "Preparing Database..."
+bundle exec rake db:migrate RAILS_ENV=$RAILS_ENV 
+echo "Database Migration Done!"
 
 # Start sidekiq
 bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
@@ -28,3 +27,6 @@ bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
 # Start the web server
 mkdir -p ./tmp/pids
 bundle exec puma -C config/puma.rb -e $RAILS_ENV
+
+# Run commands
+exec "$@"

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# If the database exists, migrate. Otherwise setup (create and migrate)
+echo "Preparing Database..."
+bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:create db:schema:load
+echo "Database Migration Done!"
+
+# Start sidekiq
+bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
+
+# Start the web server
+mkdir -p ./tmp/pids
+bundle exec puma -C config/puma.rb -e $RAILS_ENV
+
+# Run commands
+exec "$@"

--- a/docker/run_test.sh
+++ b/docker/run_test.sh
@@ -9,7 +9,7 @@ done
 
 if [ $interactive = true ]
   then
-    docker compose -p exhibits-test -f compose.test.yaml run --entrypoint=bash webapp
+    docker compose -p exhibits-test -f compose.test.yaml run webapp bash
   else
     docker compose -p exhibits-test -f compose.test.yaml run webapp bundle exec rspec
 fi


### PR DESCRIPTION
- Int/stg/prod used a db prep script that was only intended for dev and test. This PR renames docker entrypoint scripts to make more obvious who does what and updates int/stg/prod db prep to only run migrations, never load the db from schema.
- Fixes docker test scripts so that it doesn't overwrite build_test entrypoint script and ensures `bundle install` is always run.
- Removes letter_opener gem bc docker not compatible with launching a browser to view emails (discovered first by @sarah-cul!)