### PR TITLE
LP-1177 Add clearer focus indicator to carousel buttons

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -28,7 +28,6 @@ a {
 	}
 }
 
-
 p, li {
 	font-size: 1.1rem;
 }
@@ -74,6 +73,12 @@ p, li {
 }
 .breadcrumb-item.active {
 	color: inherit;
+}
+
+// Add clearer focus indicator to carousel previous and next buttons; uses default bootstrap color variable
+a.carousel-control-prev:focus > span, 
+a.carousel-control-next:focus > span {
+	outline: $link-hover-color auto 5px;
 }
 
 // MEDIA QUERIES


### PR DESCRIPTION
Currently, there isn’t a clear focus indicator for the previous and next arrows in the Spotlight carousel block. The bootstrap default is just a very subtle change in color (grey vs. black). This adds a blue outline, using the default bootstrap color variable for other focus indicators. 