### PR TITLE
LP-1155: Set up sidekiq service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN bundle config set --local with "${RAILS_ENV}" && \
     find ${BUNDLE_PATH}/ -name "*.o" -delete
 
 COPY . .
-RUN bundle exec rake assets:precompile && rm .env
+RUN rm .env
 
 ################################################################################
 # Final image for integration/staging/production

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ WORKDIR ${APP_PATH}
 COPY ./Gemfile ./Gemfile.lock ./
 RUN bundle config set --local with "${RAILS_ENV}" && \
     bundle config set --local without "${BUNDLE_WITHOUT}" && \
+    bundle config set --local path "${BUNDLE_PATH}" && \
     bundle install && \
     gem install aws-sdk-s3 && \
     rm -rf ${BUNDLE_PATH}/cache/*.gem && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,9 +103,7 @@ ENV RAILS_ENV=${RAILS_ENV} \
 # exhibits_cron - .ebextentions/tmp_cleanup.config
 # localtime adjustment - .ebextentions/system_time.config
 COPY ./cron/exhibits_cron /etc/cron.d/exhibits_cron
-RUN groupadd -r $GROUP && useradd -r -g $GROUP $USER && \
-    mkdir -p /home/${USER} && \
-    chown ${USER}:${GROUP} /home/${USER} && \
+RUN groupadd -r $GROUP && useradd -mr -g $GROUP $USER && \
     chmod gu+rw /var/run && chmod gu+s /usr/sbin/cron && \
     crontab -u root /etc/cron.d/exhibits_cron && \
     ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime

--- a/compose.integration.yaml
+++ b/compose.integration.yaml
@@ -18,3 +18,16 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
+    depends_on:
+      - sidekiq
+
+  sidekiq:
+    build:
+      context: .
+      args:
+        BUNDLE_WITHOUT: "development test"
+        RACK_ENV: integration
+        RAILS_ENV: integration
+    entrypoint: docker/run_sidekiq.sh
+    env_file:
+      - .env

--- a/compose.integration.yaml
+++ b/compose.integration.yaml
@@ -1,5 +1,8 @@
 # Docker compose file for integration environment
-# Run with: docker compose up
+# Run with: docker compose -f compose.integration.yaml up
+#
+# For local development testing of the integration container:
+# consider setting up a redis container, instead of connecting to the remote redis host.
 
 services:
   webapp:

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -1,5 +1,5 @@
 # Docker compose file for production environment
-# Run with: docker compose up
+# Run with: docker compose -f compose.production.yaml up
 
 services:
   webapp:

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -16,3 +16,16 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
+    depends_on:
+      - sidekiq
+
+  sidekiq:
+    build:
+      context: .
+      args:
+        BUNDLE_WITHOUT: "development integration test"
+        RACK_ENV: production
+        RAILS_ENV: production
+    entrypoint: docker/run_sidekiq.sh
+    env_file:
+      - .env

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -16,3 +16,16 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
+    depends_on:
+      - sidekiq
+
+  sidekiq:
+    build:
+      context: .
+      args:
+        BUNDLE_WITHOUT: "development test"
+        RACK_ENV: staging
+        RAILS_ENV: staging
+    entrypoint: docker/run_sidekiq.sh
+    env_file:
+      - .env

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -1,5 +1,5 @@
 # Docker compose file for staging environment
-# Run with: docker compose up
+# Run with: docker compose -f compose.production.yaml up
 
 services:
   webapp:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,7 @@ services:
       - mysql
       - redis
       - solr
+      - sidekiq
 
   mysql:
     image: mariadb:10.6
@@ -54,6 +55,16 @@ services:
       - 6379:6379
     volumes:
       - redis:/data
+
+  sidekiq:
+    build:
+      context: .
+      target: development
+    entrypoint: docker/run_sidekiq.sh
+    depends_on:
+      - redis
+    env_file:
+      - .env
 
 volumes:
   db-data:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,12 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "exhibits_#{Rails.env}"
-  config.debug_logger = Logger.new(Rails.root.join('log', 'debug.log'))
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = ::Logger::Formatter.new
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # provides access to IRB console on exception pages
   # config.web_console.whitelisted_ips = ENV['IP_WHITELIST'] if ENV['IP_WHITELIST'].present?

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -94,7 +94,6 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
-  config.debug_logger = Logger.new(Rails.root.join('log', 'debug.log'))
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,6 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
-  config.debug_logger = Logger.new(Rails.root.join('log', 'debug.log'))
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -94,7 +94,6 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
-  config.debug_logger = Logger.new(Rails.root.join('log', 'debug.log'))
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -21,6 +21,11 @@ echo "Preparing database..."
 bundle exec rake db:migrate RAILS_ENV=$RAILS_ENV 
 echo "Database migration done!"
 
+# Precompile assets
+echo "Compiling assets..."
+bundle exec rake assets:precompile
+echo "Compiling assets done!"
+
 # Start the web server
 mkdir -p ./tmp/pids
 bundle exec puma -C config/puma.rb -e $RAILS_ENV

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -17,12 +17,9 @@ then
 fi
 
 # Run db migrations
-echo "Preparing Database..."
+echo "Preparing database..."
 bundle exec rake db:migrate RAILS_ENV=$RAILS_ENV 
-echo "Database Migration Done!"
-
-# Start sidekiq
-bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
+echo "Database migration done!"
 
 # Start the web server
 mkdir -p ./tmp/pids

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -10,9 +10,6 @@ echo "Preparing Database..."
 bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:environment:set RAILS_ENV=development db:create db:schema:load
 echo "Database Migration Done!"
 
-# Start sidekiq
-bundle exec sidekiq -L log/sidekiq.log -e $RAILS_ENV -C config/sidekiq.yml -d
-
 # Start the web server
 mkdir -p ./tmp/pids
 bundle exec puma -C config/puma.rb -e $RAILS_ENV

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Direct logs to stdout
+export RAILS_LOG_TO_STDOUT="1"
+
 # If the database exists, migrate. Otherwise setup (create and migrate)
 echo "Preparing Database..."
 bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:environment:set RAILS_ENV=development db:create db:schema:load

--- a/docker/run_sidekiq.sh
+++ b/docker/run_sidekiq.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Get environment variables
+WORKDIR="/exhibits"
+ENVFILE="${WORKDIR}/.env"
+if [ ! -f "$ENVFILE" ]; then
+    ruby docker/get_env.rb $RAILS_ENV $WORKDIR
+fi
+
 # Start sidekiq
 echo "Starting up sidekiq..."
 bundle exec sidekiq -e $RAILS_ENV -C config/sidekiq.yml

--- a/docker/run_sidekiq.sh
+++ b/docker/run_sidekiq.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Start sidekiq
+echo "Starting up sidekiq..."
 bundle exec sidekiq -e $RAILS_ENV -C config/sidekiq.yml
 
 # Run commands

--- a/docker/run_sidekiq.sh
+++ b/docker/run_sidekiq.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Start sidekiq
+bundle exec sidekiq -e $RAILS_ENV -C config/sidekiq.yml
+
+# Run commands
+exec "$@"


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-1155

Sets up sidekiq service container instead of running as daemon on webapp. Both rails and sidekiq logs output to stdout now in containerized environments.

Note: neither logging redirects or running sidekiq as daemon is supported in newer versions of sidekiq, which we are well overdue to upgrade to. So this is also a first step towards upgrading sidekiq.