### PR TITLE
LP-1285 Clean up spacing for items-block with caption

### DIFF
--- a/app/assets/stylesheets/exhibits/_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_blocks.scss
@@ -78,3 +78,13 @@
 .thumbs-list {
 	overflow-x: auto;
 }
+
+// Balance caption text over multiple lines for item block
+.items-block .items-col .caption {
+  text-wrap: balance;
+}
+
+// Align tops of items column and text column for item block
+.items-block .items-col .box {
+  padding-top: 0; 
+}


### PR DESCRIPTION
- Balance caption text over multiple lines for image block
- Align tops of items column and text column 

**_Before_**

<img width="500" alt="Screenshot 2025-01-16 at 11 15 24 AM" src="https://github.com/user-attachments/assets/facaf719-1803-4647-be88-2d80bb42eb4f" />

**_After_**

<img width="500" alt="Screenshot 2025-01-16 at 11 15 16 AM" src="https://github.com/user-attachments/assets/37dace4d-3407-4f2b-94bc-6522e57bfbc0" />
