### PR TITLE
LP-1289 Update styling for carousel captions

### DIFF
--- a/app/assets/stylesheets/exhibits/_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_blocks.scss
@@ -1,3 +1,9 @@
+.category-caption {
+	bottom: 0 !important;
+	background: rgba(0,0,0,.5);
+	padding: 5px 0;
+}
+
 .browse-category {
   overflow: hidden;
 }

--- a/app/assets/stylesheets/exhibits/_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_blocks.scss
@@ -1,9 +1,3 @@
-.category-caption {
-	bottom: 0 !important;
-	background: rgba(0,0,0,.5);
-	padding: 5px 0;
-}
-
 .browse-category {
   overflow: hidden;
 }
@@ -50,16 +44,23 @@
   margin: 0.75em;
 }
 
-.carousel-block .carousel-caption .secondary {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
+// Move carousel caption position and adjust gradient/colors
+.carousel-block {
+  .carousel-caption {
+      position: relative;
+      color: black;
+      @include gradient-y($start-color: rgba(0,0,0,.0001), $end-color: rgba(0,0,0,.1));
+      .secondary {
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+  }
 
-.carousel-block .carousel-caption {
-  .primary a, .secondary a {
-    color: #fff;
+  .carousel-indicators li {
+      background-color: black;
   }
 }
+
 /* Static Carousel Items */
 .list-group-item {
   color: #000;

--- a/app/assets/stylesheets/exhibits/_show.scss
+++ b/app/assets/stylesheets/exhibits/_show.scss
@@ -43,8 +43,3 @@
 // Extra large devices (large desktops, 1200px and up)
 // @include media-breakpoint-up(xl) { ... }
 
-.carousel-caption {
-  position: relative;
-  background-color: #6C6C6C;
-  color: #eeeeee;
-}


### PR DESCRIPTION
This will remove the gray bar background for the carousel captions, which was already a customized Cornell style created many years ago. I believe that the gray bar was done with accessibility in mind, but I think that this update remains accessible while being more aesthetically pleasing. 

Updates include: 
- Use a transparent background with a subtle gray gradient to define the block 
- Update caption font color from white to black 
- Update carousel indicator background color (i.e. horizontal bars below text/images) to black

<img width="861" alt="Screenshot 2025-01-21 at 12 15 48 PM" src="https://github.com/user-attachments/assets/b0d9a1f8-ca10-4da0-b60e-98aa906fd94f" />
 