### PR TITLE
Remove db env vars from test env

### DIFF
--- a/.env.circleci
+++ b/.env.circleci
@@ -1,14 +1,3 @@
-# mysql_dev - host and port should match the service name in docker-compose.yml
-DATABASE_HOST=mysql
-DATABASE_PORT=3306
-DATABASE_POOL=5
-
-# shared DB credentials
-DATABASE_NAME_PREFIX=exhibits
-DATABASE_RAILS_USER=cci_user
-DATABASE_RAILS_USER_PW=cci_userpw
-DATABASE_RAILS_ROOT_PW=cci_root
-
 # solr
 SOLR_URL=http://solr:8983/solr/blacklight-core/
 


### PR DESCRIPTION
Just noticed some db vars that weren't necessary in .env.circleci. The test env uses sqlite (see config/database.yml), so these db vars aren't ever used.