### PR TITLE
LP-168 - Use image with upgraded redis 7.2 version in dev container

### DIFF
--- a/compose.base.yaml
+++ b/compose.base.yaml
@@ -11,7 +11,7 @@ services:
       - ./solr/config:/opt/solr/server/configsets/exhibitsconf
 
   redis:
-    image: redis:5-alpine
+    image: redis:7.2-bookworm
     command:
       - redis-server
 


### PR DESCRIPTION
Supports: https://culibrary.atlassian.net/browse/LP-168, in advance of: https://culibrary.atlassian.net/browse/LP-213