### PR TITLE
LP-1127 Provide the CSV file name in the email after a multiple item upload

### DIFF
--- a/app/jobs/spotlight/add_uploads_from_csv.rb
+++ b/app/jobs/spotlight/add_uploads_from_csv.rb
@@ -14,12 +14,12 @@ module Spotlight
     # NOTE: Cannot use prepend to override after_perform
     after_perform do |job|
       csv_data, exhibit, user, csv_file_name = job.arguments
+      csv_info = { csv_data: csv_data, csv_file_name: csv_file_name }
       begin
         Spotlight::IndexingCompleteMailer.documents_indexed(
-          csv_data,
+          csv_info,
           exhibit,
           user,
-          csv_file_name,
           indexed_count: job.count,
           errors: job.errors
         ).deliver_now
@@ -32,6 +32,7 @@ module Spotlight
     def perform(csv_data, exhibit, _user, csv_file_name)
       @count = 0
       @errors = {}
+      @csv_file_name = csv_file_name
 
       resources(csv_data, exhibit).each_with_index do |resource, index|
         if resource.save_and_index

--- a/app/jobs/spotlight/add_uploads_from_csv.rb
+++ b/app/jobs/spotlight/add_uploads_from_csv.rb
@@ -10,25 +10,26 @@ module Spotlight
     attr_reader :count
     attr_reader :errors
 
-    after_perform do |job|
-      csv_data, exhibit, user = job.arguments
-      ### BEGIN CUSTOMIZATION - catch exceptions from notification to prevent job from repeating if email fails
+    ### BEGIN CUSTOMIZATION - catch exceptions from notification to prevent job from repeating if email fails
       # NOTE: Cannot use prepend to override after_perform
+    after_perform do |job|
+      csv_data, exhibit, user, csv_file_name = job.arguments
       begin
         Spotlight::IndexingCompleteMailer.documents_indexed(
           csv_data,
           exhibit,
           user,
+          csv_file_name,
           indexed_count: job.count,
           errors: job.errors
         ).deliver_now
       rescue StandardError => e
         Rails.logger.error("********************** EMAIL FAILURE  => exception #{e.class.name} : #{e.message}")
       end
-      ### END CUSTOMIZATION
     end
+    ### END CUSTOMIZATION
 
-    def perform(csv_data, exhibit, _user)
+    def perform(csv_data, exhibit, _user, csv_file_name)
       @count = 0
       @errors = {}
 

--- a/app/jobs/spotlight/add_uploads_from_csv.rb
+++ b/app/jobs/spotlight/add_uploads_from_csv.rb
@@ -11,7 +11,7 @@ module Spotlight
     attr_reader :errors
 
     ### BEGIN CUSTOMIZATION - catch exceptions from notification to prevent job from repeating if email fails
-      # NOTE: Cannot use prepend to override after_perform
+    # NOTE: Cannot use prepend to override after_perform
     after_perform do |job|
       csv_data, exhibit, user, csv_file_name = job.arguments
       begin

--- a/app/mailers/spotlight/indexing_complete_mailer.rb
+++ b/app/mailers/spotlight/indexing_complete_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Notify the curator that we're finished processing a
+  # batch upload
+  class IndexingCompleteMailer < ActionMailer::Base
+    def documents_indexed(csv_data, exhibit, user, csv_file_name, indexed_count: nil, errors: [])
+      @number = indexed_count || csv_data.length
+      @exhibit = exhibit
+      @csv_file_name = csv_file_name
+      @errors = errors
+      mail(to: user.email, subject: 'Document indexing complete')
+    end
+  end
+end

--- a/app/mailers/spotlight/indexing_complete_mailer.rb
+++ b/app/mailers/spotlight/indexing_complete_mailer.rb
@@ -4,11 +4,12 @@ module Spotlight
   ##
   # Notify the curator that we're finished processing a
   # batch upload
+  # CUSTOMIZATION: bundled csv data and the csv file name into csv_info hash
   class IndexingCompleteMailer < ApplicationMailer
-    def documents_indexed(csv_data, exhibit, user, csv_file_name, indexed_count: nil, errors: [])
-      @number = indexed_count || csv_data.length
+    def documents_indexed(csv_info, exhibit, user, indexed_count: nil, errors: [])
+      @number = indexed_count || csv_info[:csv_data].length
       @exhibit = exhibit
-      @csv_file_name = csv_file_name
+      @csv_file_name = csv_info[:csv_file_name]
       @errors = errors
       mail(to: user.email, subject: 'Document indexing complete')
     end

--- a/app/mailers/spotlight/indexing_complete_mailer.rb
+++ b/app/mailers/spotlight/indexing_complete_mailer.rb
@@ -4,7 +4,7 @@ module Spotlight
   ##
   # Notify the curator that we're finished processing a
   # batch upload
-  class IndexingCompleteMailer < ActionMailer::Base
+  class IndexingCompleteMailer < ApplicationMailer
     def documents_indexed(csv_data, exhibit, user, csv_file_name, indexed_count: nil, errors: [])
       @number = indexed_count || csv_data.length
       @exhibit = exhibit

--- a/app/prepends/prepended_controllers/csv_upload_controller.rb
+++ b/app/prepends/prepended_controllers/csv_upload_controller.rb
@@ -1,0 +1,11 @@
+# Based on the Module#prepend pattern in ruby.
+# Uses the to_prepare Rails hook in application.rb to inject this module to override Spotlight::Resources::CsvUploadController
+module PrependedControllers::CsvUploadController
+  # Overrides create method to display file name in the email message
+  def create
+    csv = CSV.parse(csv_io_param, headers: true, return_headers: false).map(&:to_hash)
+    Spotlight::AddUploadsFromCsv.perform_later(csv, current_exhibit, current_user, csv_io_name)
+    flash[:notice] = t('spotlight.resources.upload.csv.success', file_name: csv_io_name)
+    redirect_to spotlight.admin_exhibit_catalog_path(current_exhibit)
+  end
+end

--- a/app/prepends/prepended_controllers/csv_upload_controller.rb
+++ b/app/prepends/prepended_controllers/csv_upload_controller.rb
@@ -3,9 +3,30 @@
 module PrependedControllers::CsvUploadController
   # Overrides create method to display file name in the email message
   def create
-    csv = CSV.parse(csv_io_param, headers: true, return_headers: false).map(&:to_hash)
-    Spotlight::AddUploadsFromCsv.perform_later(csv, current_exhibit, current_user, csv_io_name)
-    flash[:notice] = t('spotlight.resources.upload.csv.success', file_name: csv_io_name)
+    begin
+      csv = CSV.parse(csv_io_param, headers: true, return_headers: false).map(&:to_hash)
+
+      # if headers are not valid, abort because metadata may be lost
+      if invalid_headers?(csv)
+        flash[:error] = t('spotlight.resources.upload.invalid_csv_headers')
+        redirect_to spotlight.admin_exhibit_catalog_path(current_exhibit)
+        return
+      end
+
+      Spotlight::AddUploadsFromCsv.perform_later(csv, current_exhibit, current_user, csv_io_name)
+      flash[:notice] = t('spotlight.resources.upload.csv.success', file_name: csv_io_name)
+    rescue CSV::MalformedCSVError => e
+      Rails.logger.error("CSV Malformed: #{e.message}")
+      flash[:error] = t('spotlight.resources.upload.malformed_non_UTF8_csv_data', error_message: e.message)
+    end
     redirect_to spotlight.admin_exhibit_catalog_path(current_exhibit)
+  end
+
+  private
+
+  def invalid_headers?(csv)
+    expected_headers = %w[url full_title_tesim spotlight_upload_description_tesim spotlight_upload_attribution_tesim spotlight_upload_date_tesim spotlight_copyright_tesim]
+    actual_headers = csv.first.keys
+    (expected_headers - actual_headers).any?
   end
 end

--- a/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
+++ b/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
@@ -1,0 +1,12 @@
+<p><%= t :".title", csv_file_name: @csv_file_name %></p>
+
+<p><%= t :".body", count: @number, title: @exhibit.title %></p>
+
+<% if @errors.length > 0 %>
+  <p><%= t :".errors",  default: :'spotlight.catalog.reindex_progress_panel.error' %></p>
+  <ul>
+    <% @errors.each do |index, message| %>
+      <li><%= t :'.error', index: index, message: message.to_sentence %>
+    <% end %>
+  </ul>
+<% end  %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Exhibits
       # Controllers
       Spotlight::ExhibitsController.prepend PrependedControllers::ExhibitsController
       Spotlight::Resources::UploadController.prepend PrependedControllers::UploadController
+      Spotlight::Resources::CsvUploadController.prepend PrependedControllers::CsvUploadController
       Spotlight::CatalogController.prepend PrependedControllers::CatalogController
 
       # Models

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -45,6 +45,9 @@ en:
       fields:
         spotlight_copyright_tesim: Copyright
         spotlight_physicallocation_tesim: Physical Location
+    indexing_complete_mailer:
+      documents_indexed:
+        title: "Your CSV file '%{csv_file_name}' has just finished being processed."
   shared:
     site_sidebar:
       documentation: Spotlight curator documentation

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -41,7 +41,7 @@ en:
         form:
           url-field:
             help: 'Valid file types: %{extensions}. Files should be less than 10MB in size.'
-        malformed_non_UTF8_csv_data: CSV contains Malformed or non-UTF8 data.
+        malformed_non_UTF8_csv_data: CSV contains malformed or non-UTF8 data.
         invalid_csv_headers: CSV headers do not match the expected headers.
     search:
       fields:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -41,6 +41,8 @@ en:
         form:
           url-field:
             help: 'Valid file types: %{extensions}. Files should be less than 10MB in size.'
+        malformed_non_UTF8_csv_data: CSV contains Malformed or non-UTF8 data.
+        invalid_csv_headers: CSV headers do not match the expected headers.
     search:
       fields:
         spotlight_copyright_tesim: Copyright

--- a/spec/jobs/spotlight/add_uploads_from_csv_spec.rb
+++ b/spec/jobs/spotlight/add_uploads_from_csv_spec.rb
@@ -23,8 +23,12 @@ describe Spotlight::AddUploadsFromCsv do
   end
 
   it 'sends the user an email when the job is finished processing and includes the csv file name' do
-   expect(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).with(
-      data, exhibit, user, csv_file_name, indexed_count: anything, errors: anything
+    expect(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).with(
+      { csv_data: data, csv_file_name: csv_file_name },
+      exhibit,
+      user,
+      indexed_count: anything,
+      errors: anything
     ).and_return(double(deliver_now: true))
     job.perform_now
   end
@@ -55,7 +59,9 @@ describe Spotlight::AddUploadsFromCsv do
       allow(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).and_return(double(deliver_now: true))
       job.perform_now
       expect(Spotlight::IndexingCompleteMailer).to have_received(:documents_indexed).with(
-        data, exhibit, user, csv_file_name,
+        { csv_data: data, csv_file_name: csv_file_name },
+        exhibit,
+        user,
         indexed_count: 1,
         errors: {
           1 => array_including(match(Regexp.union(/relative URI: x/, /URI scheme '' not in whitelist:/))),

--- a/spec/jobs/spotlight/add_uploads_from_csv_spec.rb
+++ b/spec/jobs/spotlight/add_uploads_from_csv_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 # Tweaks add_uploads_from_csv_spec.rb from blacklight-spotlight gem since we're overriding the whole job
 describe Spotlight::AddUploadsFromCsv do
-  subject(:job) { described_class.new(data, exhibit, user) }
+  subject(:job) { described_class.new(data, exhibit, user, csv_file_name) }
 
   let(:exhibit) { create(:exhibit) }
   let(:user) { exhibit.users.first }
+  let(:csv_file_name) { 'test.csv' }
   let(:data) do
     [
       { 'url' => 'x' },
@@ -19,6 +20,13 @@ describe Spotlight::AddUploadsFromCsv do
 
   before do
     allow(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).and_return(double(deliver_now: true))
+  end
+
+  it 'sends the user an email when the job is finished processing and includes the csv file name' do
+   expect(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).with(
+      data, exhibit, user, csv_file_name, indexed_count: anything, errors: anything
+    ).and_return(double(deliver_now: true))
+    job.perform_now
   end
 
   context 'with empty data' do
@@ -47,7 +55,7 @@ describe Spotlight::AddUploadsFromCsv do
       allow(Spotlight::IndexingCompleteMailer).to receive(:documents_indexed).and_return(double(deliver_now: true))
       job.perform_now
       expect(Spotlight::IndexingCompleteMailer).to have_received(:documents_indexed).with(
-        data, exhibit, user,
+        data, exhibit, user, csv_file_name,
         indexed_count: 1,
         errors: {
           1 => array_including(match(Regexp.union(/relative URI: x/, /URI scheme '' not in whitelist:/))),

--- a/spec/prepends/prepended_controllers/csv_upload_controller_spec.rb
+++ b/spec/prepends/prepended_controllers/csv_upload_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+# Tests overrides in PrependedControllers::CsvUploadController
+describe Spotlight::Resources::CsvUploadController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:exhibit) { create(:exhibit) }
+  let(:user) { create(:user) }
+  let(:valid_csv) do
+    "url,full_title_tesim,spotlight_upload_description_tesim,spotlight_upload_attribution_tesim," \
+    "spotlight_upload_date_tesim,spotlight_copyright_tesim\n" \
+    "s3.bucket/image1.jpg,Item Title,Item Description,Jane Doe,Aug 2024,2000"
+  end
+
+  let(:malformed_csv) do
+    "url,full_title_tesim,spotlight_upload_description_tesim,spotlight_upload_attribution_tesim," \
+    "s3.bucket/image1.jpg,\"Item Title,Item Description\n" \
+    "s3.bucket/image2.jpg,Item Title,Item Description"
+  end
+
+  let(:invalid_csv_headers) do
+    "url,woops,spotlight_upload_description_tesim,spotlight_upload_attribution_tesim," \
+    "spotlight_upload_date_tesim,spotlight_copyright_tesim\n" \
+    "s3.bucket/image1.jpg,Item Title,Item Description,Jane Doe,Aug 2024,2000"
+  end
+
+  before do
+    allow(controller).to receive(:current_exhibit).and_return(exhibit)
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:csv_io_name).and_return("test.csv")
+    sign_in user
+
+    # Stub the authorization check
+    allow(controller).to receive(:authorize!).and_return(true)
+  end
+
+  describe "POST create" do
+    context "when valid csv file is used" do
+      before do
+        allow(controller).to receive(:csv_io_param).and_return(valid_csv)
+      end
+
+      it "shows the success flash message" do
+        post :create, params: { exhibit_id: exhibit.id }
+        expect(flash[:notice]).to eq(I18n.t('spotlight.resources.upload.csv.success', file_name: "test.csv"))
+      end
+    end
+
+    context "when malformed csv file is used" do
+      before do
+        allow(controller).to receive(:csv_io_param).and_return(malformed_csv)
+      end
+
+      it "shows the malformed error flash message" do
+        post :create, params: { exhibit_id: exhibit.id }
+        expect(flash[:error]).to eq(I18n.t('spotlight.resources.upload.malformed_non_UTF8_csv_data'))
+      end
+    end
+
+    context "when invalid csv headers are used" do
+      before do
+        allow(controller).to receive(:csv_io_param).and_return(invalid_csv_headers)
+      end
+
+      it "shows the invalid csv headers error flash message" do
+        post :create, params: { exhibit_id: exhibit.id }
+        expect(flash[:error]).to eq(I18n.t('spotlight.resources.upload.invalid_csv_headers'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the email sent after the job finishes processing, the name of the csv file will be displayed.

Additional changes include: 
- will abort the upload if the headers are not correct, or the csv is not formatted correctly.. it will show the error message on the UI. I thought this would be better so that the upload is not done and metadata is not lost