### PR TITLE
LP-1258 Remove i18n translations for all_fields search and relevance sort labels

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,9 +26,9 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'full_title_tesim'
 
-    config.add_search_field 'all_fields', label: I18n.t('spotlight.search.fields.search.all_fields')
+    config.add_search_field 'all_fields', label: "All Fields"
 
-    config.add_sort_field 'relevance', sort: 'score desc, id asc', label: I18n.t('spotlight.search.fields.sort.relevance')
+    config.add_sort_field 'relevance', sort: 'score desc, id asc', label: "relevance"
 
     config.add_field_configuration_to_solr_request!
 


### PR DESCRIPTION
These i18n translations in the catalog controller were broken. I was not able to fix the translations themselves, but when you provide a string as the label instead, it will override whatever default is in the locale file for English. This also does not prevent one from adding translations for other languages.