### PR TITLE
LP-1332 Fix Bulk Update Uploader by customizing file storage location

### DIFF
--- a/app/uploaders/spotlight/bulk_updates_uploader.rb
+++ b/app/uploaders/spotlight/bulk_updates_uploader.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Overrides Spotlight::BulkUpdatesUploader storage configuration to prevent use of AWS S3 storage when configured as Spotlight::Engine.config.uploader_storage
+# Fixes broken Spotlight processing job /app/jobs/spotlight/process_bulk_updates_csv_job.rb, which assumes local filepath (not S3) 
+# Customizes storage location to tmp directory
+module Spotlight
+  # :nodoc:
+  class BulkUpdatesUploader < CarrierWave::Uploader::Base
+    storage :file
+
+    def store_dir
+      Rails.root.join("tmp/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}")
+    end
+  end
+end

--- a/app/uploaders/spotlight/bulk_updates_uploader.rb
+++ b/app/uploaders/spotlight/bulk_updates_uploader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Overrides Spotlight::BulkUpdatesUploader storage configuration to prevent use of AWS S3 storage when configured as Spotlight::Engine.config.uploader_storage
-# Fixes broken Spotlight processing job /app/jobs/spotlight/process_bulk_updates_csv_job.rb, which assumes local filepath (not S3) 
+# Fixes broken Spotlight processing job /app/jobs/spotlight/process_bulk_updates_csv_job.rb, which assumes local filepath (not S3)
 # Customizes storage location to tmp directory
 module Spotlight
   # :nodoc:

--- a/spec/uploaders/spotlight/bulk_updates_uploader_spec.rb
+++ b/spec/uploaders/spotlight/bulk_updates_uploader_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Spotlight::BulkUpdatesUploader do
+  subject(:bulk_updates_uploader) { described_class.new(mounter, 'mounted_as') }
+
+  let(:mounter) { Spotlight::BulkUpdate.new(id: '1') }
+
+  describe '#store_dir' do
+    let(:store_dir) { bulk_updates_uploader.store_dir }
+
+    it 'includes filepath to tmp directory' do
+      expect(store_dir).to eq Rails.root.join("tmp/uploads/spotlight/bulk_update/mounted_as/#{mounter.id}")
+    end
+  end
+end


### PR DESCRIPTION
This update overrides the storage configuration for Spotlight::BulkUpdatesUploader to prevent the use of AWS S3 storage when configured as Spotlight::Engine.config.uploader_storage. It fixes the Spotlight processing job /app/jobs/spotlight/process_bulk_updates_csv_job.rb, which assumes a local filepath and was breaking when the related csv file was stored in a S3 bucket. This also customizes storage location to the tmp directory rather than the default public directory. 