### PR TITLE
Upgrade sidekiq to v7, run sidekiq as embedded process, remove sidekiq container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'rdoc', require: false
 gem 'riiif'
 gem 'rsolr'
 gem 'ruby-oembed'
-gem 'sidekiq', '~> 6' # TODO: NEEDS UPGRADE
+gem 'sidekiq', '~> 7'
 gem 'sitemap_generator'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       carrierwave (>= 2.0, < 4)
     chronic (0.10.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -457,14 +457,14 @@ GEM
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.13)
-    rack-session (1.0.2)
-      rack (< 3)
+    rack (3.1.14)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.2.1)
+      rack (>= 3)
     rails (8.0.2)
       actioncable (= 8.0.2)
       actionmailbox (= 8.0.2)
@@ -506,7 +506,8 @@ GEM
     rdoc (6.13.1)
       psych (>= 4.0.0)
     redcarpet (3.6.1)
-    redis (4.8.1)
+    redis-client (0.24.0)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -597,10 +598,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -673,7 +676,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -737,7 +739,7 @@ DEPENDENCIES
   rspec_junit_formatter
   ruby-oembed
   selenium-webdriver
-  sidekiq (~> 6)
+  sidekiq (~> 7)
   sitemap_generator
   solr_wrapper (>= 0.3)
   sqlite3

--- a/compose.integration.yaml
+++ b/compose.integration.yaml
@@ -21,16 +21,3 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
-    depends_on:
-      - sidekiq
-
-  sidekiq:
-    build:
-      context: .
-      args:
-        BUNDLE_WITHOUT: "development test"
-        RACK_ENV: integration
-        RAILS_ENV: integration
-    entrypoint: docker/run_sidekiq.sh
-    env_file:
-      - .env

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -16,16 +16,3 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
-    depends_on:
-      - sidekiq
-
-  sidekiq:
-    build:
-      context: .
-      args:
-        BUNDLE_WITHOUT: "development integration test"
-        RACK_ENV: production
-        RAILS_ENV: production
-    entrypoint: docker/run_sidekiq.sh
-    env_file:
-      - .env

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -16,16 +16,3 @@ services:
       - PORT=9292
     ports:
       - 9292:9292
-    depends_on:
-      - sidekiq
-
-  sidekiq:
-    build:
-      context: .
-      args:
-        BUNDLE_WITHOUT: "development test"
-        RACK_ENV: staging
-        RAILS_ENV: staging
-    entrypoint: docker/run_sidekiq.sh
-    env_file:
-      - .env

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,6 @@ services:
       - mysql
       - redis
       - solr
-      - sidekiq
 
   mysql:
     image: mariadb:10.6
@@ -55,21 +54,6 @@ services:
       - 6379:6379
     volumes:
       - redis:/data
-
-  sidekiq:
-    build:
-      context: .
-      target: development
-    entrypoint: docker/run_sidekiq.sh
-    image: exhibits
-    stdin_open: true
-    tty: true
-    env_file:
-      - .env
-    volumes:
-      - .:/exhibits
-    depends_on:
-      - redis
 
 volumes:
   db-data:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,6 +27,27 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# preloading the application is necessary to ensure
+# the configuration in your initializer runs before
+# the boot callback below.
+preload_app!
+
+x = nil
+on_worker_boot do
+  x = Sidekiq.configure_embed do |config|
+    # config.logger.level = Logger::DEBUG
+    config.queues = %w[default]
+    config.concurrency = 2
+  end
+  x.run
+end
+
+on_worker_shutdown do
+  x&.stop
+end
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 9292)
 


### PR DESCRIPTION
Created new ecs task definition 9 which removes the sidekiq container now that sidekiq 7 allows us to run sidekiq as an embedded puma process.

This also resolves an issue @ebtoner found where Bulk Updates were broken because the sidekiq process was looking for the upload csv on the sidekiq container instead of on the webapp container.

Marking this PR as draft because I'd like to verify this works with elastic beanstalk on stg, but stg is currently down...

If this seems good to go, this adds another dependency to deploying https://github.com/cul-it/exhibits-library-cornell-edu/pull/733 to prod: we'll need to first point prod's REDIS_HOST to the new valkey instance (https://culibrary.atlassian.net/browse/LP-168).