### PR TITLE
LP-172 Hide the constraints container on the catalog show page

### DIFF
--- a/app/assets/stylesheets/exhibits/_catalog_show.scss
+++ b/app/assets/stylesheets/exhibits/_catalog_show.scss
@@ -1,7 +1,13 @@
-// Add space between metadata and viewer
 .blacklight-catalog-show {
+
+	// Add space between metadata and viewer
 	.document-metadata {
 		margin-top: 2rem;
+	}
+
+	// LP-172 Hide the constraints container (Start Over and Back to Search) on the show page
+	.constraints-container {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
Removes Back to Search and Start Over buttons from catalog show page (Start Over still viewable on search results page itself)