### PR TITLE
remove button styles on the black print theme

### DIFF
--- a/app/assets/stylesheets/application_blackprint.scss
+++ b/app/assets/stylesheets/application_blackprint.scss
@@ -28,26 +28,6 @@ a, .page-link {
   color: $blackprint-light-blue;
 }
 
-//buttons
-
-.btn-primary,
-.btn-primary:hover,
-.btn-primary:active,
-.btn-outline-secondary:hover, 
-.btn-outline-secondary:active,
-.btn-outline-secondary:not(:disabled):not(.disabled).active,
-.show > .btn-outline-secondary.dropdown-toggle,
-.nav-pills .nav-link.active,
-.page-item.active .page-link {
-  background-color: $blackprint-dark-blue;
-  border-color: $blackprint-dark-blue; 
-}
-
-.btn-outline-secondary {
-  border-color: $blackprint-dark-blue;
-  color: $blackprint-dark-blue;
-}
-
 //navbar 
 
 #exhibit-navbar {


### PR DESCRIPTION
they aren't needed anymore because the buttons are now hidden.. this is what they were originally used for:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d27718de-9e95-4c83-a72b-eba56996e00a" />

but they are causing accessibility issues on the admin dashboard:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/e9f8744d-f28e-4e7c-8133-e1f4ee224b30" />
