### PR TITLE
LP-1168 Resize masthead so that image is not stretched out

### DIFF
--- a/app/assets/stylesheets/application_rmc-legacy.scss
+++ b/app/assets/stylesheets/application_rmc-legacy.scss
@@ -21,7 +21,6 @@
     // Center masthead image
     background-position: center;
     border: none;
-    height: 180px;
 
     @media (max-width: breakpoint-max('md')) {
       // For smaller screen sizes, zoom in on solid background color on left side of modified RMC masthead image

--- a/app/assets/stylesheets/exhibits/_header.scss
+++ b/app/assets/stylesheets/exhibits/_header.scss
@@ -94,20 +94,23 @@ header {
 			}
 		}
 	}
+	.background-container {
+		height: 180px;
+	}
 }
 
 // background treatment only for mastheads with images
 .image-masthead {
 	.site-title-wrapper {
-		margin-top: 1rem;
 		display: inline-block;
 		background: rgba(0,0,0,.7);
+		margin: 1rem 0;
 		padding: .5rem 1rem;
 	}
 }
 .site-title-container {
 	max-height: none;
-	padding-bottom: 2rem !important;
+	padding: 1rem 1.2rem !important;
 }
 
 .site-nav {


### PR DESCRIPTION
This sets up height to 180px, which matched the height of the supplied image. Previously, the masthead was stretched out and therefore hard to modify in Spotlight. 

This also makes some minor changes to the title container to ensure even spacing.