### PR TITLE
Remove time.formats from devise_invitable i18n to attempt to resolve …

### DIFF
--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -23,9 +23,3 @@ en:
         accept: "Accept invitation"
         accept_until: "This invitation will be due in %{due_date}."
         ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
-  time:
-    formats:
-      devise:
-        mailer:
-          invitation_instructions:
-            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -80,7 +80,7 @@ describe 'Adding exhibit items', type: :system do
       fill_in 'Description', with: 'A new item description'
       click_button 'Save changes'
 
-      sleep 1
+      sleep 2
       expect(page).to have_text('Description: A new item description', normalize_ws: true)
       expect(page).to have_text('My item title')
       expect(page).to have_text('1 of 2', normalize_ws: true)


### PR DESCRIPTION
…inconsistent i18n missing rspec error

An attempt to fix sporadic rspec errors like in the following build: https://jenkins.library.cornell.edu/view/Exhibits/job/exhibits-rspec-rubocop/1066/console

Failures:

  1) Adding exhibit items updating items updates existing items with new uploaded files
     Failure/Error: raise exception.respond_to?(:to_exception) ? exception.to_exception : exception

     I18n::MissingTranslationData:
       Translation missing: en.time.formats.long

My guess is this is because we override en.time.formats from rails i18n in the devise_invitable.en.yml (which was generated from the devise_invitable install generator). And since it looks like we override the invitation_instructions mailer views that use this i18n key in spotlight, I've just removed this en.time.formats key from our devise_invitable.en.yml. Hopefully this fixes it, but hard to know since the error was inconsistent?? If anyone sees this error again in jenkins or circleci, please let me know!