### PR TITLE
Fix freight-text-pro font setting in blackprint theme

### DIFF
--- a/app/assets/stylesheets/application_blackprint.scss
+++ b/app/assets/stylesheets/application_blackprint.scss
@@ -100,7 +100,9 @@ a, .page-link {
 
       // exhibit subtitle
       small {
-        font-family: 'Freight Text Pro bold', serif;
+        font-family: freight-text-pro, serif;
+        font-weight: 700;
+        font-style: normal;
         color: $blackprint-yellow;
         padding-top: 0 !important;
       }
@@ -111,7 +113,9 @@ a, .page-link {
 // feature page titles 
 #content {
   h1.page-title {
-    font-family: 'Freight Text Pro bold', serif;
+    font-family: freight-text-pro, serif;
+    font-weight: 700;
+    font-style: normal;
   }
   .page-title {
     background: url('spotlight/themes/blackprint/Swirl5.png') no-repeat;
@@ -136,7 +140,9 @@ a, .page-link {
   
   .subtitle {
     font-size: .65em;
-    font-family: 'Freight Text Pro bold', serif;
+    font-family: freight-text-pro, serif;
+    font-weight: 700;
+    font-style: normal;
 
     &::before {
       content: "(";
@@ -150,7 +156,9 @@ a, .page-link {
   }
 
   .title {
-    font-family: 'Freight Text Pro bold', serif;
+    font-family: freight-text-pro, serif;
+    font-weight: 700;
+    font-style: normal;
     background: url('spotlight/themes/blackprint/Swirl5.png') no-repeat;
     background-position: 0% 30%;
     padding-left: 3rem;


### PR DESCRIPTION
It looks like we're defaulting to the serif font for the blackprint exhibit - updated the blackprint theme to use the Freight Text Pro Bold styling from Adobe Typekit.

What blackprint feature page title font looks like now on prod:
![Screenshot 2025-07-02 at 9 21 10 AM](https://github.com/user-attachments/assets/7da87231-a3e4-4924-93bb-364929c39064)

What blackprint feature page title font looks like with this PR:
![Screenshot 2025-07-02 at 9 21 05 AM](https://github.com/user-attachments/assets/a1d0b3ba-3a19-46de-bad3-288cffaec329)