### PR TITLE
LP-1479 Accessibility -  empty <ul> container in nav bar

### DIFF
--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -1,12 +1,16 @@
-<ul class="navbar-nav me-auto">
-  <% ### BEGIN CUSTOMIZATION elr - only show header links to logged in users %>
-  <% if current_user %>
-    <%= render_nav_actions do |config, action|%>
-      <li class="nav-item"><%= action %></li>
-    <% end %>
+<% nav_actions = capture do %>
+  <%= render_nav_actions do |config, action|%>
+    <li class="nav-item"><%= action %></li>
   <% end %>
-  <% ### END CUSTOMIZATION %>
-</ul>
+<% end %>
+
+<% ### BEGIN CUSTOMIZATION - only show header links to logged in users %>
+<% if nav_actions.present? and current_user %>
+  <ul class="navbar-nav me-auto'">
+    <%= nav_actions %>
+  </ul>
+<% end %>
+<% ### END CUSTOMIZATION %>
 
 <ul class="navbar-nav">
   <%= render '/spotlight/shared/locale_picker' %>
@@ -38,15 +42,15 @@
         </li>
       </ul>
     </li>
-  <% ### BEGIN CUSTOMIZATION elr - remove login link from header (see footer for new location) %>
-  <% # else % >
-     # <li class="nav-item">
-     #   < %= link_to t('spotlight.header_links.login'), main_app.new_user_session_path, class: 'nav-link' % >
-     # </li>
-  %>
-  <% ### END CUSTOMIZATION %>
+    <% ### BEGIN CUSTOMIZATION elr - remove login link from header (see footer for new location) %>
+    <% # else % >
+       # <li class="nav-item">
+       #   < %= link_to t('spotlight.header_links.login'), main_app.new_user_session_path, class: 'nav-link' % >
+       # </li>
+    %>
+    <% ### END CUSTOMIZATION %>
   <% end %>
-  <% if current_exhibit && show_contact_form? %>
+  <% if current_exhibit and show_contact_form? %>
     <li class="nav-item">
       <%= link_to t('spotlight.header_links.contact'), spotlight.new_exhibit_contact_form_path(current_exhibit),
         data: { bs_toggle: 'collapse', bs_target: '#report-problem-form' },


### PR DESCRIPTION
Fixed by syncing our utility nav bar customization with the up-to-date Spotlight file - see https://github.com/projectblacklight/spotlight/blob/8695f3663b2214da068282d307846c030a37021d/app/views/shared/_user_util_links.html.erb