### PR TITLE
LP-1484 Accessibility: Improve color contrast for bootstrap secondary buttons

### DIFF
--- a/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
@@ -12,6 +12,29 @@
 	}
 }
 
+// Override btn-secondary - use blacklight-cornell styling and add white background
+.btn-secondary, .btn-outline-secondary.active {
+	background-color: $concrete;
+}
+.btn-secondary:hover {
+	background-color: $concrete-hover;
+}
+.btn-outline-secondary {
+	background-color: white;
+	border-color: $concrete;
+	color: $almost-black;
+}
+.btn-outline-secondary:hover {
+	background-color: $concrete-hover;
+	border-color: $concrete-hover;
+	color: white;
+}
+
+// Override btn-outline-primary - add white background
+.btn-outline-primary {
+	background-color: white;
+}
+
 // #433 - color contrast is insufficient 
 .breadcrumb-item.active {
 	color: inherit;
@@ -19,8 +42,8 @@
 
 // #433 - color contrast is insufficient
 .page-item.active .page-link {
-	border-color: $almost-black;
-	background-color: $almost-black;
+	border-color: $concrete;
+	background-color: $concrete;
 }
 
 // #500 - update blockquote style
@@ -29,5 +52,3 @@
 	padding: 1rem 0 .5rem 1rem;
 	border-left: 5px solid #eee;
 }
-
-

--- a/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/exhibits/_bootstrap_overrides.scss
@@ -12,7 +12,7 @@
 	}
 }
 
-// Override btn-secondary - use blacklight-cornell styling and add white background
+// Override btn-secondary / btn-outline-secondary - use blacklight-cornell styling and add white background for outlined button
 .btn-secondary, .btn-outline-secondary.active {
 	background-color: $concrete;
 }

--- a/app/assets/stylesheets/exhibits/_variables_exhibitions.scss
+++ b/app/assets/stylesheets/exhibits/_variables_exhibitions.scss
@@ -4,7 +4,8 @@
 $cornell-red: #b31b1b;
 $cornell-medium-blue: #0068ac;
 
-$warm-gray: #c3c1bd;
 $almost-black: #222222;
-
+$concrete: #757068;
+$concrete-hover: #605C56;
 $pale-gray: #f5f5f5;
+$warm-gray: #c3c1bd;


### PR DESCRIPTION
Pulled most of styling from blacklight-cornell (see https://github.com/cul-it/blacklight-cornell/blob/e0c383607ca22392db4a473c44b8b2abed3dca96/blacklight-cornell/app/assets/stylesheets/cornell/_base.scss#L60) and added white background to outline buttons, in order to avoid future issues with custom themes: 

<img width="376" height="141" alt="Screenshot 2025-08-07 at 10 54 22 AM" src="https://github.com/user-attachments/assets/fbb9d833-6733-4b59-818e-8bce28455557" />

Also updated page navigation bar to match new "concrete" color: 

<img width="257" height="93" alt="Screenshot 2025-08-07 at 10 54 45 AM" src="https://github.com/user-attachments/assets/3dfa763d-5c62-457e-9f76-153f2dc60323" />
