### PR TITLE
Adjustment to copyright statement spacing

### DIFF
--- a/app/assets/stylesheets/exhibits/_footer.scss
+++ b/app/assets/stylesheets/exhibits/_footer.scss
@@ -10,8 +10,11 @@ footer {
 }
 
 .copyright {
+  margin-bottom: 3rem;
+  hr {
+    margin: 0 0 3rem 0;
+  }
   p {
     font-size: 1rem;
-    padding: 5px;
   }
 }


### PR DESCRIPTION
Narrowing the space above the copyright hr and evening out the space above and below the copyright paragraphs


<img width="1164" height="509" alt="Screenshot 2025-08-07 at 12 54 53 PM" src="https://github.com/user-attachments/assets/60348b92-edda-4748-b282-838f9b6578bf" />
