### PR TITLE
Adjust hr margins

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -13,6 +13,10 @@ p, li {
 	font-size: 1.1rem;
 }
 
+hr {
+	margin: 1.2rem 0;
+}
+
 #main-container {
 	padding-bottom: 3em;
 }


### PR DESCRIPTION
Related to the setup of the Plant Based exhibit, but could benefit the general exhibit design as well. Default was `hr { margin: 1rem 0; }` so this is very minor adjustment to even out spacing with adjacent blocks.