### PR TITLE
show user survey button on all exhibits

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -22,7 +22,7 @@ p, li {
   font-size: 1.2rem !important;
   width: 180px !important;
   right: -181px !important; 
-  top: 15% !important;
+  top: 10% !important;
 }
 
 // MEDIA QUERIES

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -63,15 +63,13 @@
     <%# END CUSTOMIZATION %>
     </main>
 
-    <% unless current_user %>
-      <%# LibWizard form - user survey (added 8/2025) %>
-      <div id="form_button_8b9b567539972b5c14544a42a31bb827"></div>
-      <script
-        type="text/javascript"
-        src="https://cornell.libwizard.com/embed_button.php?id=8b9b567539972b5c14544a42a31bb827&noheader=1&type=floatButton&open-button-text=Help%20us%20redesign!&open-button-color=%23b31b1b&text-color=%23ffffff&axis-position=25%25&button-location=right"
-        crossorigin="anonymous">
-      </script>
-    <% end %>
+    <%# LibWizard form - user survey (added 8/2025) %>
+    <div id="form_button_8b9b567539972b5c14544a42a31bb827"></div>
+    <script
+      type="text/javascript"
+      src="https://cornell.libwizard.com/embed_button.php?id=8b9b567539972b5c14544a42a31bb827&noheader=1&type=floatButton&open-button-text=Help%20us%20redesign!&open-button-color=%23b31b1b&text-color=%23ffffff&axis-position=25%25&button-location=right"
+      crossorigin="anonymous">
+    </script>
 
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -41,7 +41,7 @@
     <%= yield(:meta) %>
     <%= javascript_tag "window.addEventListener('load', () => $.fx.off = true)" if Rails.env.test? %>
   </head>
-  <body class="<%= render_body_class %>">
+  <body class="<%= render_body_class %>" data-turbo="false">
     <%= render partial: 'shared/body_preamble' %>
     <%= render blacklight_config.skip_link_component.new(render_search_link: should_render_spotlight_search_bar?) do %>
       <%= content_for(:skip_links) %>
@@ -62,6 +62,16 @@
     <% end %>
     <%# END CUSTOMIZATION %>
     </main>
+
+    <% unless current_user %>
+      <%# LibWizard form - user survey (added 8/2025) %>
+      <div id="form_button_8b9b567539972b5c14544a42a31bb827"></div>
+      <script
+        type="text/javascript"
+        src="https://cornell.libwizard.com/embed_button.php?id=8b9b567539972b5c14544a42a31bb827&noheader=1&type=floatButton&open-button-text=Help%20us%20redesign!&open-button-color=%23b31b1b&text-color=%23ffffff&axis-position=25%25&button-location=right"
+        crossorigin="anonymous">
+      </script>
+    <% end %>
 
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>

--- a/app/views/spotlight/exhibits/_exhibits.html.erb
+++ b/app/views/spotlight/exhibits/_exhibits.html.erb
@@ -3,11 +3,3 @@
 <%# END CUSTOMIZATION %>
   <%= render collection: exhibits, partial: 'exhibit_card', as: 'exhibit' %>
 </div>
-
-<%# LibWizard form - user survey (added 8/2025) %>
-<div id="form_button_8b9b567539972b5c14544a42a31bb827"></div>
-<script
-  type="text/javascript"
-  src="https://cornell.libwizard.com/embed_button.php?id=8b9b567539972b5c14544a42a31bb827&noheader=1&type=floatButton&open-button-text=Help%20us%20redesign!&open-button-color=%23b31b1b&text-color=%23ffffff&axis-position=25%25&button-location=right"
-  crossorigin="anonymous">
-</script>


### PR DESCRIPTION
LibWizard User survey button now showing on all pages in the exhibit for visitors

moved slightly higher so it doesn't just overlap on the masthead

