### PR TITLE
LP-1500 Fix lib wizard form breaking features

### DIFF
--- a/app/assets/stylesheets/exhibits/_base.scss
+++ b/app/assets/stylesheets/exhibits/_base.scss
@@ -21,20 +21,47 @@ hr {
 	padding-bottom: 3em;
 }
 
-// LibWizard form - Help us redesign! button
+// LibWizard form - Help us redesign! button is sticky
 .lwz-btn {
-  font-size: 1.2rem !important;
-  width: 180px !important;
-  right: -181px !important; 
-  top: 10% !important;
+  position: fixed;
+  right: 16px;
+  top: 30%;
+  z-index: 9999;
+  background: #b31b1b;
+  color: #fff;
+  padding: 6px;
+  border-radius: 6px;
+  text-decoration: none;
+  text-align: center;
+  transform: rotate(90deg) translateY(-50%);
+  transform-origin: right top;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  width: 180px;
+}
+.lwz-btn:hover {
+  background: #8a1616;
 }
 
 // MEDIA QUERIES
 // -------------------------
 
-// Small devices (landscape phones, 576px and up)
-// @include media-breakpoint-up(sm) {
-// }
+// Small devices (landscape phones, 576px and down,)
+@include media-breakpoint-down(sm) {
+  // LibWizard form - Help us redesign! button is static
+  .lwz-btn {
+    position: static;
+    transform: none;
+    width: 200px;
+    margin: 1em auto;
+    display: block;
+    border-radius: 6px;
+    top: auto;
+    right: auto;
+  }
+}
 
 // Medium devices (tablets, 768px and up)
 // @include media-breakpoint-up(md) {

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -41,7 +41,7 @@
     <%= yield(:meta) %>
     <%= javascript_tag "window.addEventListener('load', () => $.fx.off = true)" if Rails.env.test? %>
   </head>
-  <body class="<%= render_body_class %>" data-turbo="false">
+  <body class="<%= render_body_class %>">
     <%= render partial: 'shared/body_preamble' %>
     <%= render blacklight_config.skip_link_component.new(render_search_link: should_render_spotlight_search_bar?) do %>
       <%= content_for(:skip_links) %>
@@ -64,12 +64,9 @@
     </main>
 
     <%# LibWizard form - user survey (added 8/2025) %>
-    <div id="form_button_8b9b567539972b5c14544a42a31bb827"></div>
-    <script
-      type="text/javascript"
-      src="https://cornell.libwizard.com/embed_button.php?id=8b9b567539972b5c14544a42a31bb827&noheader=1&type=floatButton&open-button-text=Help%20us%20redesign!&open-button-color=%23b31b1b&text-color=%23ffffff&axis-position=25%25&button-location=right"
-      crossorigin="anonymous">
-    </script>
+    <a href="https://cornell.libwizard.com/f/cul-online-exhibits-feedback"
+      target="_blank" rel="noopener" class="lwz-btn">Help us redesign!
+    </a>
 
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>


### PR DESCRIPTION
- Fix lib wizard form breaking features (reindexing items) by opening the form in new tab instead of embedding the form on exhibits

- responsive view will not have a sticky button, the button will just show at the bottom of the page so it doesn't block content

<img width="250" alt="image" src="https://github.com/user-attachments/assets/89a52719-9c34-4873-ac88-8d78fa84ea14" />

<img width="220" alt="image" src="https://github.com/user-attachments/assets/26a929bf-d62d-4b27-b333-7644c0f7d3d0" />

