### PR TITLE
LP-1533 send the cron logging to the container STDOUT

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
+# Send the cron output to container STDOUT so its accessible in CloudWatch log streams
+set :output, '/proc/1/fd/1'
 
 # Ensure crunner has access to envs
 # Support for running rake via whenever on docker


### PR DESCRIPTION
send the cron job output to container STDOUT so that it can be found in the cloudwatch log streams