### PR TITLE
Sets up cron jobs in dev environment for debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,11 @@ ENV RAILS_ENV=development \
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/go/dockerfile-user-best-practices/
-RUN groupadd -r $GROUP && useradd -mr -g $GROUP $USER
+# Can we run this clean up cron as crunner instead of root?
+COPY ./cron/exhibits_cron /etc/cron.d/exhibits_cron
+RUN groupadd -r $GROUP && useradd -mr -g $GROUP $USER && \
+    chmod gu+rw /var/run && chmod gu+s /usr/sbin/cron && \
+    crontab -u root /etc/cron.d/exhibits_cron
 USER $USER
 
 # Install application gems and node modules
@@ -100,9 +104,10 @@ ENV RAILS_ENV=${RAILS_ENV} \
     GROUP=crunnergrp \
     AWS_DEFAULT_REGION=us-east-1
 
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
 # Can we run this clean up cron as crunner instead of root?
-# exhibits_cron - .ebextentions/tmp_cleanup.config
-# localtime adjustment - .ebextentions/system_time.config
+# Includes localtime adjustment
 COPY ./cron/exhibits_cron /etc/cron.d/exhibits_cron
 RUN groupadd -r $GROUP && useradd -mr -g $GROUP $USER && \
     chmod gu+rw /var/run && chmod gu+s /usr/sbin/cron && \

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -5,6 +5,10 @@ set -e
 # Direct logs to stdout
 export RAILS_LOG_TO_STDOUT="1"
 
+# Uncomment to test cron jobs in dev environment
+# bundle exec whenever --update-crontab --set "environment=${RAILS_ENV}"
+# cron
+
 # If the database exists, migrate. Otherwise setup (create and migrate)
 echo "Preparing Database..."
 bundle exec rake db:migrate 2>/dev/null || bundle exec rake db:environment:set RAILS_ENV=development db:create db:schema:load


### PR DESCRIPTION
Attempt to make cron debugging easier in development environment by setting up cron files and permissions by default and adding comments for how to actually run cron.