### PR TITLE
add dir size information to the logging for the clear_cache cron job

### DIFF
--- a/lib/tasks/spotlight.rake
+++ b/lib/tasks/spotlight.rake
@@ -11,15 +11,16 @@ namespace :spotlight do
       end
       # Abort if the size of the tmp/network_files directory cannot be determined
       size = `du -sh tmp/network_files`.split("\t").first
-      unless $CHILD_STATUS.exitstatus.zero?
+      unless $CHILD_STATUS.success?
         Rails.logger.error("Aborting spotlight:riiif:clear_cache rake task. Failed to get size of tmp/network_files.")
         next
       end
       Rails.logger.info("Beginning spotlight:riiif:clear_cache rake task. Size of tmp/network_files/ is currently #{size}.")
-      Rails.logger.info("Cache exceeds 50GB threshold, starting cleanup.") if size.match(/^(\d+(?:\.\d+)?)G$/) && Regexp.last_match(1).to_f > 50
+
       # If the size is over 50GB, delete the oldest files until under 50GB
       deleted_file_count = 0
       while !size.nil? && size.match(/^(\d+(?:\.\d+)?)G$/) && Regexp.last_match(1).to_f > 50
+        Rails.logger.info("Cache exceeds 50GB threshold, starting cleanup.") if deleted_file_count.zero?
         # Get the oldest file in the tmp/network_files directory
         oldest_file = `ls -t tmp/network_files | tail -n 1`.chomp
         # Delete the oldest file


### PR DESCRIPTION
Log the before and after directory size info when the clear cache cron job runs

<img width="900" height="83" alt="image" src="https://github.com/user-attachments/assets/f26eb6ba-da88-4a73-994a-2606c7485cd4" />
