### PR TITLE
LP-1487 Add imageLoaderLimit to osd config to render initial image tile first

### DIFF
--- a/app/components/openseadragon_embed_component.rb
+++ b/app/components/openseadragon_embed_component.rb
@@ -1,4 +1,4 @@
-# Overrides Blacklight::Gallery::OpenseadragonEmbedComponent to set osd initialPage setting, default to first page
+# Overrides Blacklight::Gallery::OpenseadragonEmbedComponent to set osd imageLoaderLimit and initialPage configurations
 class OpenseadragonEmbedComponent < Blacklight::Gallery::OpenseadragonEmbedComponent
   def initialize(initial_page: 0, **kwargs)
     super
@@ -6,8 +6,23 @@ class OpenseadragonEmbedComponent < Blacklight::Gallery::OpenseadragonEmbedCompo
     @initial_page = initial_page
   end
 
+  def osd_config
+    {
+      crossOriginPolicy: false,
+      zoomInButton: "#{@id_prefix}-zoom-in",
+      zoomOutButton: "#{@id_prefix}-zoom-out",
+      homeButton: "#{@id_prefix}-home",
+      fullPageButton: "#{@id_prefix}-full-page",
+      nextButton: "#{@id_prefix}-next",
+      previousButton: "#{@id_prefix}-previous",
+      # Downloads one image at a time, so that the initial image tile is rendered before additional tiles
+      imageLoaderLimit: 1
+    }
+  end
+
   def osd_config_referencestrip
     {
+      # Set Reference Strip initial page to default to first page
       initialPage: @initial_page,
       showReferenceStrip: true,
       sequenceMode: true,

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -3,7 +3,7 @@
 ActiveSupport::Reloader.to_prepare do
   ### START CUSTOMIZATION (elr) - new initializer for S3 storage support
   if S3.connected?
-    Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+    Riiif::Image.file_resolver = Riiif::HttpFileResolver.new
     Riiif::Image.file_resolver.id_to_uri = lambda do |id|
       aws_file = Spotlight::FeaturedImage.find(id).image.file
       raise Riiif::ImageNotFoundError, "unable to find file for #{id}" if aws_file.nil?


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/LP-1487

Before: The embedded image viewer tried to load all images tiles at once, resulting in zoom-in details sometimes loading before the full-size image. Example -

<img width="1338" height="596" alt="Screenshot 2025-10-02 at 3 28 24 PM" src="https://github.com/user-attachments/assets/b3eb562e-0275-4d91-914d-9466fe54fab5" />

After: The embedded image will load the initial image display first, before any details. Example -

<img width="1364" height="547" alt="Screenshot 2025-10-02 at 3 28 44 PM" src="https://github.com/user-attachments/assets/c85054b6-0054-4388-a791-e4dc05fc69c1" />

See https://openseadragon.github.io/docs/OpenSeadragon.ImageLoader.html for details. 

I also updated `Riiif::HTTPFileResolver.new` to `Riiif::HttpFileResolver.new` based on a deprecation warning.
