### PR TITLE
Update custom themes for Spotlight v5.2.0

### DIFF
--- a/app/assets/stylesheets/application_blackprint.scss
+++ b/app/assets/stylesheets/application_blackprint.scss
@@ -112,14 +112,13 @@ a, .page-link {
 
 // feature page titles 
 #content {
-  h1.page-title {
-    font-family: freight-text-pro, serif;
-    font-weight: 700;
-    font-style: normal;
-  }
+
   .page-title {
     background: url('spotlight/themes/blackprint/Swirl5.png') no-repeat;
     background-position: 0 0.5rem;
+    font-family: freight-text-pro, serif;
+    font-size: 2.5rem;
+    font-style: normal;
     padding-bottom: 1rem;
     padding-left: 3rem;
   } 

--- a/app/assets/stylesheets/application_dr-joyce-brothers.scss
+++ b/app/assets/stylesheets/application_dr-joyce-brothers.scss
@@ -122,7 +122,7 @@ body, header {
 }
 
 #content {
-  h1.page-title {
+  h2.page-title {
     font-family: 'Mutable-SemiBold';
   }
 


### PR DESCRIPTION
Styles for custom theme page titles need to be updated because of change in Spotlight v5.2.0 - see https://github.com/projectblacklight/spotlight/pull/3583 for details