### PR TITLE
LP-1781 Improve margins for page item and browse category widgets

### DIFF
--- a/app/assets/stylesheets/exhibits/_browse_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_browse_blocks.scss
@@ -2,6 +2,10 @@
 // ---------------------- //
 // Includes Browse Categories and Browse Group Categories blocks; also impacts Pages block
 
+.browse-categories {
+  margin: 0; 
+}
+
 .browse-category {
   overflow: hidden;
 }
@@ -12,6 +16,12 @@
 [data-sidebar="false"],
 [data-sidebar="true"] {
   &[class*="categories-"] {
+    justify-content: center;
+
+    .box {
+      margin: 1rem;
+    }
+
     .browse-category {
       max-width: $maximum-tile-width;
       max-height: $maximum-tile-width * $aspect-ratio-factor-4x3;
@@ -20,25 +30,40 @@
     }
   }
 	&[class*="categories-"]:not(.categories-1):not(.categories-2):not(.categories-3):not(.categories-4) {
-    .browse-category {
-      @media (min-width: breakpoint-min("sm")) {
+    
+    @media (min-width: breakpoint-min("sm")) {
+      .browse-category{
         width: $sm-three-tile-width;
         height: $sm-three-tile-width * $aspect-ratio-factor-4x3;
       }
+    }
 
-      @media (min-width: breakpoint-min("md")) {
+    @media (min-width: breakpoint-min("md")) {
+      .browse-category{
         width: $md-three-tile-width;
         height: $md-three-tile-width * $aspect-ratio-factor-4x3;
       }
+    }
 
-      @media (min-width: breakpoint-min("lg")) {
+    @media (min-width: breakpoint-min("lg")) {
+      .browse-category{
         width: $lg-three-tile-width;
         height: $lg-three-tile-width * $aspect-ratio-factor-4x3;
       }
+    }
 
-      @media (min-width: breakpoint-min("xl")) {
+    @media (min-width: breakpoint-min("xl")) {
+      .box {
+        margin: 0.25rem;
+      }
+      
+      .browse-category{
         width: $xl-five-tile-width;
         height: $xl-five-tile-width * $aspect-ratio-factor-4x3;
+      }
+
+      &.browse-categories {
+        margin: 0.75rem 0.25rem;
       }
     }
   }


### PR DESCRIPTION
Jira: https://culibrary.atlassian.net/browse/LP-1781

Updated the margins so that the boxes are even for the following scenarios, while retaining the existing responsive design for smaller screen sizes.

**When there are multiple rows within a single instance of the widget**

Before: 
<img width="1385" height="342" alt="Screenshot 2026-04-06 at 11 43 28 AM" src="https://github.com/user-attachments/assets/26ee45a2-1a08-4926-a715-520138bae53d" />

After:
<img width="1370" height="355" alt="Screenshot 2026-04-06 at 11 44 49 AM" src="https://github.com/user-attachments/assets/e8c068d8-c5d1-4327-8ad1-c68d0f81797c" />

**When multiple instances of the widget are adjacent**

Before, with three different instances of the widget with larger boxes: 
<img width="1428" height="714" alt="Screenshot 2026-04-06 at 11 42 49 AM" src="https://github.com/user-attachments/assets/c2a0f9ff-6210-4648-9a22-93ec96b29546" />

After: 
<img width="1396" height="722" alt="Screenshot 2026-04-06 at 11 44 28 AM" src="https://github.com/user-attachments/assets/95934aeb-1616-409f-9def-58d215c335c1" />

Before, with two different instances of the widget with smaller boxes: 
<img width="1380" height="343" alt="Screenshot 2026-04-06 at 11 43 17 AM" src="https://github.com/user-attachments/assets/9c1767b6-f9aa-4d3c-87a7-0bf3f98e97ce" />

After: 
<img width="1372" height="345" alt="Screenshot 2026-04-06 at 11 44 39 AM" src="https://github.com/user-attachments/assets/4c6d2d7d-0a49-4a5c-8428-faac98610e9f" />