### PR TITLE
LP-1635 Accessibility improvements

### DIFF
--- a/app/assets/stylesheets/exhibits/_browse_blocks.scss
+++ b/app/assets/stylesheets/exhibits/_browse_blocks.scss
@@ -6,10 +6,6 @@
   margin: 0; 
 }
 
-.browse-category {
-  overflow: hidden;
-}
-
 // Tile sizing
 // Override Spotlight to enable multiple rows if tiles >5
 // Fixes: https://github.com/cul-it/exhibits-library-cornell-edu/issues/448
@@ -27,6 +23,11 @@
       max-height: $maximum-tile-width * $aspect-ratio-factor-4x3;
       width: $xs-one-tile-width;
       height: $xs-one-tile-width * $aspect-ratio-factor-4x3;
+
+      .category-title {
+        font-size: 1.25rem;
+        line-height: 1.5;
+      }
     }
   }
 	&[class*="categories-"]:not(.categories-1):not(.categories-2):not(.categories-3):not(.categories-4) {

--- a/app/assets/stylesheets/exhibits/_variables_exhibitions.scss
+++ b/app/assets/stylesheets/exhibits/_variables_exhibitions.scss
@@ -2,7 +2,7 @@
 // -----------------//
 
 $cornell-red: #b31b1b;
-$cornell-medium-blue: #0068ac;
+$cornell-medium-blue: #005588;
 
 $almost-black: #222222;
 $concrete: #757068;

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <% ### BEGIN CUSTOMIZATION (mhk) - UI theme %>
 <% require 'version' %>
 <% if current_exhibit && @page.is_a?(Spotlight::HomePage) %>
-<div class="container copyright">
+<div class="container copyright" role="contentinfo" aria-label="Copyright Information">
   <hr/>
   <p>The materials included within this site are intended for educational uses only. Unless stated otherwise, 
   all graphics and text presented in this exhibit are protected by U.S. copyright law. Persons wishing to 


### PR DESCRIPTION
- fixing color contrast issue for links, a slightly darker blue meets the contrast ratio requirements
- adding a copyright labeled landmark in the footer addresses Aria accessibility issue by helping screen readers identify that block of text more quickly
- fix page widget issue with long titles by reducing font size slightly, and removing the hidden overflow so that no text is clipped. 
This is the AA level issue:
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/64aedcda-6e0e-49ff-b4b8-407460542509" />


This is what it looks like after the fix, the browser font size set to default (recommended) of Medium

<img width="800" alt="image" src="https://github.com/user-attachments/assets/6fd4c051-8a5f-4d91-917c-4fea8caf82cb" />

This is what it will look like when the browser is set to Extra Large.. text gets BIG. Our site is not unique to this issue.. its hard to design for this font size setting, but one of the things we could do is consider using max 3 pages per row when the page titles on the exhibit are so long, or reducing page title length.  
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/a87dac7c-9412-48c9-b11b-9fbfd29b2d98" />

