### PR TITLE
Update riiif to latest git commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     libghc-libyaml-dev=0.1.* \
     libvips \
     libvips-dev \
-    libvips-tools
+    libvips-tools \
+    # Remove git once riif install is switched back to rubygems.org/ version
+    git 
 
 RUN npm install --global yarn@1.22.*
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'propshaft'
 # Use Puma as the app server
 gem 'puma', '< 7'
 gem 'rdoc', require: false
-gem 'riiif'
+gem 'riiif', github: "sul-dlss/riiif", ref: "56e7e13" # Remove :git and :ref when riiif 2.8.2 is released
 gem 'rsolr'
 gem 'ruby-oembed'
 gem 'sidekiq', '~> 8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/sul-dlss/riiif.git
+  revision: 56e7e131b867b4b71ab165642cc392850f8c2c41
+  ref: 56e7e13
+  specs:
+    riiif (2.8.1)
+      deprecation (>= 1.0.0)
+      iiif-image-api (>= 0.1.0)
+      railties (>= 4.2, < 9)
+      ruby-vips
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -113,7 +124,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
@@ -347,7 +358,7 @@ GEM
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -362,7 +373,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.3)
+    json (2.19.4)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -402,7 +413,7 @@ GEM
       logger
     mini_mime (1.1.5)
     minitar (1.1.0)
-    minitest (6.0.3)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -525,7 +536,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -550,11 +561,6 @@ GEM
       railties (>= 7.0)
     retriable (3.4.1)
     rexml (3.4.4)
-    riiif (2.8.1)
-      deprecation (>= 1.0.0)
-      iiif-image-api (>= 0.1.0)
-      railties (>= 4.2, < 9)
-      ruby-vips
     roar (1.2.0)
       representable (~> 3.1)
     roar-rails (1.2.0)
@@ -764,7 +770,7 @@ DEPENDENCIES
   rails (~> 8.1.0)
   rails-controller-testing
   rdoc
-  riiif
+  riiif!
   rsolr
   rspec-activemodel-mocks
   rspec-its
@@ -789,7 +795,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 3.4.9p82
+  ruby 3.4.9p82
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
Jira: https://culibrary.atlassian.net/browse/LP-1803

This updates riiif to https://github.com/sul-dlss/riiif/commit/56e7e131b867b4b71ab165642cc392850f8c2c41. This is temporary fix until riiif 2.8.2 is released. 

See also https://github.com/sul-dlss/riiif/pull/159 for more details about bug fix. 