### PR TITLE
Add Qualified Dublin Core fields to new exhibits

### DIFF
--- a/app/models/concerns/cul/exhibit_defaults.rb
+++ b/app/models/concerns/cul/exhibit_defaults.rb
@@ -5,6 +5,24 @@ module Cul
   module ExhibitDefaults
     extend ActiveSupport::Concern
 
+    DCTERMS = [
+      { dcterms: 'creator', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'contributor', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'created', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'issued', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'language', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'spatial', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'publisher', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'subject', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'temporal', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'type', field_type: 'vocab', is_multiple: false },
+      { dcterms: 'extent', field_type: 'text', is_multiple: false },
+      { dcterms: 'format', field_type: 'text', is_multiple: false },
+      { dcterms: 'relation', field_type: 'text', is_multiple: false },
+      { dcterms: 'source', field_type: 'text', is_multiple: false },
+      { dcterms: 'identifier', field_type: 'vocab', is_multiple: true }
+    ].freeze
+
     included do
       before_save :set_published
       after_save :send_status_notification
@@ -31,27 +49,9 @@ module Cul
       return unless previously_new_record?
 
       # Add Qualified Dublin Core fields (using DCMI Metadata Terms)
-      dublin_core_fields = [
-        { dcterms: 'creator', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'contributor', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'created', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'issued', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'language', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'spatial', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'publisher', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'subject', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'temporal', field_type: 'vocab', is_multiple: true },
-        { dcterms: 'type', field_type: 'vocab', is_multiple: false },
-        { dcterms: 'extent', field_type: 'text', is_multiple: false },
-        { dcterms: 'format', field_type: 'text', is_multiple: false },
-        { dcterms: 'relation', field_type: 'text', is_multiple: false },
-        { dcterms: 'source', field_type: 'text', is_multiple: false },
-        { dcterms: 'identifier', field_type: 'vocab', is_multiple: true }
-      ]
-
-      dublin_core_fields.each do |field|
+      DCTERMS.each do |field|
         suffix = Spotlight::Engine.config.custom_field_types[field[:field_type].to_sym][:suffix] || Spotlight::Engine.config.solr_fields.text_suffix
-        
+
         Spotlight::CustomField.new(
           exhibit: self,
           field: "dcterms_#{field[:dcterms]}#{suffix}",

--- a/app/models/concerns/cul/exhibit_defaults.rb
+++ b/app/models/concerns/cul/exhibit_defaults.rb
@@ -8,8 +8,7 @@ module Cul
     DCTERMS = [
       { dcterms: 'creator', field_type: 'vocab', is_multiple: true },
       { dcterms: 'contributor', field_type: 'vocab', is_multiple: true },
-      { dcterms: 'created', field_type: 'vocab', is_multiple: true },
-      { dcterms: 'issued', field_type: 'vocab', is_multiple: true },
+      { dcterms: 'date', field_type: 'vocab', is_multiple: true },
       { dcterms: 'language', field_type: 'vocab', is_multiple: true },
       { dcterms: 'spatial', field_type: 'vocab', is_multiple: true },
       { dcterms: 'publisher', field_type: 'vocab', is_multiple: true },
@@ -54,7 +53,7 @@ module Cul
 
         Spotlight::CustomField.new(
           exhibit: self,
-          field: "dcterms_#{field[:dcterms]}#{suffix}",
+          field: "#{field[:dcterms]}#{suffix}",
           label: I18n.t("spotlight.search.fields.dcterms.labels.#{field[:dcterms]}", default: field[:dcterms].humanize),
           short_description: I18n.t("spotlight.search.fields.dcterms.short_descriptions.#{field[:dcterms]}", default: nil),
           field_type: field[:field_type],

--- a/app/models/concerns/cul/exhibit_defaults.rb
+++ b/app/models/concerns/cul/exhibit_defaults.rb
@@ -8,6 +8,7 @@ module Cul
     included do
       before_save :set_published
       after_save :send_status_notification
+      after_save :add_dublin_core_metadata
     end
 
     def set_published
@@ -23,6 +24,43 @@ module Cul
     def send_status_notification
       return unless saved_change_to_published?
       ExhibitStatusMailer.send_exhibit_status_email(self).deliver_later
+    end
+
+    def add_dublin_core_metadata
+      # Limit to new exhibits to avoid adding fields if the exhibit is updated or published after creation
+      return unless previously_new_record?
+
+      # Add Qualified Dublin Core fields (using DCMI Metadata Terms)
+      dublin_core_fields = [
+        { dcterms: 'creator', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'contributor', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'created', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'issued', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'language', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'spatial', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'publisher', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'subject', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'temporal', field_type: 'vocab', is_multiple: true },
+        { dcterms: 'type', field_type: 'vocab', is_multiple: false },
+        { dcterms: 'extent', field_type: 'text', is_multiple: false },
+        { dcterms: 'format', field_type: 'text', is_multiple: false },
+        { dcterms: 'relation', field_type: 'text', is_multiple: false },
+        { dcterms: 'source', field_type: 'text', is_multiple: false },
+        { dcterms: 'identifier', field_type: 'vocab', is_multiple: true }
+      ]
+
+      dublin_core_fields.each do |field|
+        suffix = Spotlight::Engine.config.custom_field_types[field[:field_type].to_sym][:suffix] || Spotlight::Engine.config.solr_fields.text_suffix
+        
+        Spotlight::CustomField.new(
+          exhibit: self,
+          field: "dcterms_#{field[:dcterms]}#{suffix}",
+          label: I18n.t("spotlight.search.fields.dcterms.labels.#{field[:dcterms]}", default: field[:dcterms].humanize),
+          short_description: I18n.t("spotlight.search.fields.dcterms.short_descriptions.#{field[:dcterms]}", default: nil),
+          field_type: field[:field_type],
+          is_multiple: field[:is_multiple]
+        ).save!
+      end
     end
   end
 end

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -51,16 +51,13 @@ en:
       fields: 
         dcterms: 
           labels: 
-            created: Date Created
-            issued: Date Issued
             spatial: Location
             temporal: Time Period
             type: Work Type
           short_descriptions:
             creator: "\"An entity primarily responsible for making the resource.\" (DCMI Metadata Terms)"
             contributor: "\"An entity responsible for making contributions to the resource.\" (DCMI Metadata Terms)"
-            created: "\"Date of creation of the resource.\" (DCMI Metadata Terms)"
-            issued: "\"Date of formal issuance (e.g., publication) of the resource.\" (DCMI Metadata Terms)"
+            date: "\"A point or period of time associated with an event in the lifecycle of the resource.\" (DCMI Metadata Terms)"
             language: "\"A language of the intellectual content of the resource.\" (DCMI Metadata Terms)"
             publisher: "\"An entity responsible for making the resource available.\" (DCMI Metadata Terms)"
             subject: "\"The topic of the resource.\" (DCMI Metadata Terms)"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -48,8 +48,31 @@ en:
       edit_fields:
         help: Enter a valid Cornell NetID email address in the form netid@cornell.edu
     search:
-      fields:
-        spotlight_copyright_tesim: Copyright
+      fields: 
+        dcterms: 
+          labels: 
+            created: Date Created
+            issued: Date Issued
+            spatial: Location
+            temporal: Time Period
+            type: Work Type
+          short_descriptions:
+            creator: "\"An entity primarily responsible for making the resource.\" (DCMI Metadata Terms)"
+            contributor: "\"An entity responsible for making contributions to the resource.\" (DCMI Metadata Terms)"
+            created: "\"Date of creation of the resource.\" (DCMI Metadata Terms)"
+            issued: "\"Date of formal issuance (e.g., publication) of the resource.\" (DCMI Metadata Terms)"
+            language: "\"A language of the intellectual content of the resource.\" (DCMI Metadata Terms)"
+            publisher: "\"An entity responsible for making the resource available.\" (DCMI Metadata Terms)"
+            subject: "\"The topic of the resource.\" (DCMI Metadata Terms)"
+            spatial: "\"The spatial characteristics of the resource.\" (DCMI Metadata Terms)"
+            temporal: "\"The temporal characteristics of the resource.\" (DCMI Metadata Terms)"
+            type: "\"The nature or genre of the resource.\" (DCMI Metadata Terms)"
+            extent: "\"The size or duration of the resource.\" (DCMI Metadata Terms)"
+            format: "\"The file format, physical medium, or dimensions of the resource.\" (DCMI Metadata Terms)"
+            relation: "\"A related resource.\" (DCMI Metadata Terms)"
+            source: "\"A related resource from which the described resource is derived.\" (DCMI Metadata Terms)"
+            identifier: "\"An unambiguous reference to the resource within a given context.\" (DCMI Metadata Terms)"
+        spotlight_copyright_tesim: Rights
         spotlight_physicallocation_tesim: Physical Location
   shared:
     site_sidebar:


### PR DESCRIPTION
Jira: https://culibrary.atlassian.net/browse/LP-1559

The goal here would be to add custom qualified dublin core fields by default when creating a new exhibit. 

Benefits: 
- Unlike the default upload fields, the custom fields allow for multivalued entries and controlled vocabs. This will also allow for the easier use of the facet configurations in Spotlight.
- A curator could edit field labels without it affecting the underlying field name or remove unwanted fields.
- It does not require migrating metadata from past sites, unless we want to change the default upload fields (though perhaps we will want to do this in some cases, for example "Attribution"). 

Potential issues: 
- When the custom fields are sent to Solr, the exhibit slug is added a prefix to the field (ex. exhibit_test-site_dcterms_creator_tesim). I experimented with removing this, but it would require overriding the custom field model. I'm not sure that this is actually an issue, but definitely something to think about. 
- Currently, the following code is causing an error when trying to upload custom fields via the CSV file, which should be possible otherwise: https://github.com/cul-it/exhibits-library-cornell-edu/blob/7c4174fed7f003c36db33c6e3fce7daa8376a476/app/prepends/prepended_controllers/csv_upload_controller.rb#L27

Other considerations: 
I think that this approach is simpler than trying to build more functionality into the default upload fields or creating additioanl features, such as drop-down menus for attributes (ex. "Created" and "Issued" for Date).

Screenshot of example output on Metadata admin page: 

<img width="998" height="709" alt="Screenshot 2026-06-11 at 12 03 45 PM" src="https://github.com/user-attachments/assets/c820be02-7b7a-4ea6-bbc6-a25153491d63" />
