### PR TITLE
use s3 bucket for mailer logo

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -14,9 +14,9 @@
       <p style="margin: 0 0 6px 5px;"><a href="mailto:help-exhibits-library@cornell.edu" style="color: #005588;text-decoration: none;">help-exhibits-library@cornell.edu</a></p>
       <p style="margin: 0 0 6px 5px;">
         <% if ENV['S3_BUCKET_DOMAIN'] %>
-          <%= link_to image_tag("#{ENV['S3_BUCKET_DOMAIN']}/mailer_assets/mailer-CULibraryRed.jpg", alt: 'Cornell University Library Logo', style: 'max-width: 175px; height: auto;'), 'http://www.library.cornell.edu' %>
+          <%= link_to image_tag("#{ENV['S3_BUCKET_DOMAIN']}/mailer_assets/mailer-CULibraryRed.jpg", alt: 'Cornell University Library Logo', style: 'max-width: 175px; height: auto;'), 'https://www.library.cornell.edu' %>
         <% else %>
-          <%= link_to 'Cornell University Library', 'http://www.library.cornell.edu' %>
+          <%= link_to 'Cornell University Library', 'https://www.library.cornell.edu' %>
         <% end %>
       </p>
     </div>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -22,16 +22,18 @@
   <body style="margin: 20px; font-family: Arial, Helvetica, sans-serif; font-size: 1rem; line-height: 1.5;">
     <%= yield %>
     <p style="margin: 0 0 6px 0px;"><span style="text-transform: uppercase;"><%= t('spotlight.mailers.environment') %>:</span> <%= Rails.env %></p>
-    <footer style="font-size: 0.9rem; margin-top: 40px;">
+    <div style="font-size: 0.9rem; margin-top: 40px;">
       <p style="margin: 0 0 6px 5px;"><%= t('spotlight.mailers.email_closing') %>,</p>
       <p style="margin: 0 0 6px 5px;">Online Exhibitions</p>
       <p style="margin: 0 0 6px 5px;"><a href="mailto:help-exhibits-library@cornell.edu" style="color: #005588;text-decoration: none;">help-exhibits-library@cornell.edu</a></p>
       <p style="margin: 0 0 6px 5px;">
-        <a href="http://www.library.cornell.edu">
-          <%= image_tag 'mailer-CULibraryRed.jpg', alt: 'Cornell University Library Logo', style: 'max-width: 175px; height: auto;' %>
-        </a>
+        <% if ENV['S3_BUCKET_DOMAIN'] %>
+          <%= link_to image_tag("#{ENV['S3_BUCKET_DOMAIN']}/mailer_assets/mailer-CULibraryRed.jpg", alt: 'Cornell University Library Logo', style: 'max-width: 175px; height: auto;'), 'http://www.library.cornell.edu' %>
+        <% else %>
+          <%= link_to 'Cornell University Library', 'http://www.library.cornell.edu' %>
+        <% end %>
       </p>
-    </footer>
+    </div>
   </body>
 </html>
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,21 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <% # if email client supports embedded CSS, definition lists in feedback email will be formatted %>
-    <style>
-      /* Email styles need to be inline */
-      dl { margin: 0; padding-top: 0px }
-      dt::after {
-        content: ":"; 
-        margin-right: 20px;
-      }
-      dd { margin-left: 0px; }
-      dl > dt, dl > dd { display: inline; }
-      dl > dt::before {
-        content: "\A";
-        white-space: pre;
-      }
-    </style>
+    <% # Email styles need to be inline %>
   </head>
 
   <body style="margin: 20px; font-family: Arial, Helvetica, sans-serif; font-size: 1rem; line-height: 1.5;">


### PR DESCRIPTION
- change footer element to a div -> looks better in email client
- remove style for the dl which seems not to work in email clients - (only impacts the feedback email)
- use s3 bucket to for storing the image logo so its supported in all our environments

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/eb68c717-6eee-4b84-b407-b41357ccc183" />

--------------

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e1af5841-3798-48cc-a023-3f0f9ef6596d" />

---------
<img width="506" alt="image" src="https://github.com/user-attachments/assets/02276604-2981-446a-a343-2259a8751c31" />
